### PR TITLE
fix: 3 P1 bugs + Feature 013 spec

### DIFF
--- a/specs/013-user-preference-persistence/checklists/requirements.md
+++ b/specs/013-user-preference-persistence/checklists/requirements.md
@@ -1,0 +1,125 @@
+# Requirements Checklist: User Preference Persistence (013)
+
+## Functional Requirements Validation
+
+### FR-001: Preference Detection
+- [ ] Bot correctly identifies "don't remind me about groceries unless I ask" as a lasting preference
+- [ ] Bot correctly identifies "no Jason appointment reminders" as a lasting preference
+- [ ] Bot correctly identifies "check the time before making recommendations" as a lasting preference
+- [ ] Bot does NOT treat "okay, I'll check groceries later" as a preference (conversational, not a rule)
+- [ ] Bot does NOT treat "quiet day" as a persistent preference (already handled by Feature 003 as a temporary toggle)
+- [ ] Bot asks for clarification on ambiguous statements like "leave me alone"
+
+### FR-002: Persistent Storage
+- [ ] Preferences are written to `data/user_preferences.json` (local) or `/app/data/user_preferences.json` (Docker)
+- [ ] File follows `_DATA_DIR` pattern from `conversation.py` and `discovery.py`
+- [ ] Preferences survive Docker container restart (verified with `docker compose restart fastapi`)
+- [ ] Preferences survive full redeployment (`docker compose down && docker compose up`)
+- [ ] File is valid JSON after every write operation
+
+### FR-003: Per-User Isolation
+- [ ] Erin's preferences are stored under Erin's phone number
+- [ ] Jason's preferences are stored under Jason's phone number
+- [ ] Setting a preference for Erin does not affect Jason's experience
+- [ ] Listing preferences for Erin does not show Jason's preferences
+
+### FR-004: System Prompt Injection
+- [ ] Active preferences for the current user are appended to the system prompt before each message
+- [ ] Preferences are formatted clearly so Claude understands and respects them
+- [ ] System prompt injection does not break existing system prompt rules
+- [ ] Performance: adding preferences does not significantly increase response latency
+
+### FR-005: Nudge Filtering
+- [ ] Grocery opt-out suppresses grocery-related proactive nudges for that user
+- [ ] Departure opt-out suppresses departure reminder nudges for that user
+- [ ] Budget opt-out suppresses budget-related proactive nudges for that user
+- [ ] Chore opt-out suppresses chore suggestion nudges for that user
+- [ ] Nudges for non-opted-out topics are still delivered normally
+- [ ] Filtered nudges are logged (not silently dropped) for debugging
+
+### FR-006: List Preferences
+- [ ] "What are my preferences?" returns a formatted list of all active preferences
+- [ ] Each preference shows: description, category, and when it was set
+- [ ] Response uses WhatsApp formatting (bold headers, bullet lists)
+- [ ] Empty preference set returns a helpful message with examples
+
+### FR-007: Remove Preferences
+- [ ] "Start reminding me about groceries again" removes the grocery opt-out
+- [ ] "Remove preference about groceries" removes the grocery opt-out
+- [ ] "I want Jason's appointments back" removes the Jason calendar filter
+- [ ] "Clear all my preferences" removes all preferences for that user
+- [ ] Removal confirmation includes what was removed and that it takes effect immediately
+
+### FR-008: Conflicting Preferences
+- [ ] Newer preference for the same topic replaces the older one
+- [ ] Bot confirms the update, not a duplicate creation
+- [ ] If a user opts out then opts back in for the same topic, only the opt-in is active
+
+### FR-009: Confirmation Messages
+- [ ] Preference creation is confirmed with a human-readable message
+- [ ] Confirmation includes how to reverse the preference
+- [ ] Preference removal is confirmed with what was removed
+- [ ] Removal confirmation mentions the preference is no longer active
+
+### FR-010: Startup Loading
+- [ ] Preferences are loaded from disk when the module is imported (same as `conversation.py`)
+- [ ] If the file does not exist on startup, an empty preference set is used (no crash)
+- [ ] If the file is corrupted, a warning is logged and an empty preference set is used
+
+### FR-011: Atomic Writes
+- [ ] Writes go to a `.tmp` file first, then `rename()` to the final path
+- [ ] Pattern matches `_save_conversations()` in `conversation.py`
+- [ ] Concurrent reads during a write do not see partial data
+
+### FR-012: Explicit Requests Override Opt-Outs
+- [ ] Erin can ask "what's the meal plan?" even with a grocery opt-out and gets a full answer
+- [ ] Erin can ask "what's on Jason's calendar?" even with a Jason filter and gets the data
+- [ ] Opt-outs only suppress proactive/unsolicited messages, not direct requests
+
+### FR-013: Ambiguity Handling
+- [ ] "Leave me alone" prompts clarification (quiet day vs. permanent)
+- [ ] "Stop everything" prompts clarification (all nudges vs. all communication)
+- [ ] If no clarification is given, the less destructive option is chosen
+
+### FR-014: Preference Cap
+- [ ] Users cannot store more than 50 preferences
+- [ ] A warning is shown when approaching the limit (e.g., 45+)
+- [ ] Attempting to add a 51st preference returns an error with guidance to remove old ones
+
+## Integration Points
+
+### Nudge System (Feature 003)
+- [ ] `process_pending_nudges()` in `src/tools/nudges.py` checks preferences before sending
+- [ ] `scan_upcoming_departures()` respects departure nudge opt-outs
+- [ ] Quiet day (Feature 003) and preference opt-outs work independently and do not conflict
+
+### System Prompt (`src/assistant.py`)
+- [ ] Preferences are injected into the system prompt dynamically
+- [ ] Injection happens in `handle_message()` before the Claude API call
+- [ ] Existing hardcoded preferences (Rule 67: budget quiet hours) are not broken
+
+### Conversation Memory (Feature 007)
+- [ ] Preferences are NOT stored in conversation memory (they have their own file)
+- [ ] Preferences persist beyond the 24h conversation timeout
+- [ ] Preference operations (set, list, remove) are reflected in conversation context
+
+### Daily Planner / Meeting Prep
+- [ ] Topic filters (e.g., exclude Jason calendar) modify what data is fetched for briefings
+- [ ] Notification opt-outs (e.g., no groceries) suppress those sections in daily plans
+- [ ] Communication style preferences (e.g., time-awareness) shape recommendation timing
+
+## Data Integrity
+
+- [ ] JSON schema includes: id, phone, label, category, topic, original_text, created_at, active
+- [ ] Phone numbers are stored in E.164 format (matching WhatsApp webhook format)
+- [ ] Timestamps use ISO 8601 format
+- [ ] No sensitive data beyond phone numbers (already present in conversations.json)
+
+## Erin's Three Specific Preferences (Day-One Validation)
+
+- [ ] "Don't send grocery info unless I ask" -> Stored as notification opt-out, topic: groceries
+- [ ] "Don't remind me of Jason's appointments" -> Stored as topic filter, scope: jason_personal_calendar
+- [ ] "Check the time before making recommendations" -> Stored as communication style, scope: time_awareness
+- [ ] All three are honored in the daily briefing
+- [ ] All three persist across container restart
+- [ ] All three can be listed and removed

--- a/specs/013-user-preference-persistence/spec.md
+++ b/specs/013-user-preference-persistence/spec.md
@@ -1,0 +1,158 @@
+# Feature Specification: User Preference Persistence
+
+**Feature Branch**: `013-user-preference-persistence`
+**Created**: 2026-03-01
+**Status**: Draft
+**Input**: User description: "User preference persistence — bot remembers Erin and Jason's explicit opt-outs and communication preferences across conversations. When Erin says 'don't remind me about groceries unless I ask' or 'no Jason appointment reminders' or 'check the time before making recommendations', these preferences are stored persistently and honored in all future interactions. Preferences survive container restarts, can be listed ('what are my preferences?'), and removed ('start reminding me about groceries again'). Integrates with the existing nudge system (Feature 003) to filter proactive messages, and with the system prompt to shape response behavior. Preferences are per-user (per phone number). Same WhatsApp interface."
+
+## Context
+
+Erin has explicitly stated three preferences that the bot currently ignores because there is no persistence mechanism:
+
+1. **"Don't send grocery info unless I ask"** — Erin does not want proactive grocery reminders, meal plan nudges, or unsolicited grocery lists. She wants grocery information only when she explicitly asks for it.
+2. **"Don't remind me of Jason's appointments"** — Erin does not want to see Jason's calendar events in her daily briefing or proactive nudges. She only wants her own and the family calendar.
+3. **"Check the time before making recommendations"** — The bot should be time-aware when making suggestions. No dinner recommendations at 8 AM, no morning routine suggestions at 3 PM, no bedtime-related nudges at noon.
+
+Today, the bot has a 24-hour conversation window (Feature 007) and a "quiet day" toggle (Feature 003), but no mechanism to store lasting per-user preferences that survive beyond a single conversation session or container restart. The budget quiet hours rule (Rule 67 — no budget talk before 8 PM) is hardcoded in the system prompt rather than being a user-configurable preference.
+
+This feature adds a persistent, per-user preference store that is checked on every message and before every proactive nudge, allowing the bot to honor what users have explicitly asked for.
+
+## Assumptions
+
+- Storage follows the established JSON file pattern: `data/user_preferences.json` (local) or `/app/data/user_preferences.json` (Docker), using the same `_DATA_DIR` pattern as `conversations.json`, `usage_counters.json`, and `budget_pending_suggestions.json`
+- Preferences are keyed by phone number (same identifier used throughout the codebase via `PHONE_TO_NAME`)
+- Preferences are injected into the system prompt dynamically on each incoming message so Claude respects them naturally during response generation
+- The nudge system (Feature 003, `src/tools/nudges.py`) checks stored preferences before sending any proactive message
+- The daily planner and meeting prep logic in the system prompt respects preference filters (e.g., excluding Jason's calendar from Erin's briefing if she opted out)
+- No new Notion databases are needed — this is a lightweight JSON file feature
+- No new external APIs — this is purely internal state management
+- The existing WhatsApp interface is the only interaction surface
+- Atomic file writes (write-to-tmp-then-rename) are used for crash safety, following the established pattern in `conversation.py`
+- The existing hardcoded budget quiet hours (Rule 67) is a candidate for migration into user preferences in a future iteration, but is not required for this feature
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Capture & Store Preferences (Priority: P1)
+
+When Erin or Jason states a preference in natural language — such as "don't remind me about groceries unless I ask", "stop sending me Jason's appointments", or "check the time before making suggestions" — the bot recognizes this as a lasting preference (not a one-time request), stores it persistently with a human-readable label, and confirms that it has been saved. The preference survives conversation expiry, container restarts, and redeployment.
+
+**Why this priority**: Without capture and storage, no other preference functionality can work. This is the foundational building block. Erin has already stated preferences three times and been ignored — this directly addresses that frustration.
+
+**Independent Test**: Send "don't remind me about groceries unless I ask" in WhatsApp. Restart the Docker container. Send a new message. Verify that the preference is still stored by asking "what are my preferences?" and seeing the grocery opt-out listed.
+
+**Acceptance Scenarios**:
+
+1. **Given** Erin has no stored preferences, **When** she sends "don't remind me about groceries unless I ask", **Then** the bot stores a notification opt-out preference for the "groceries" topic under Erin's phone number and confirms: "Got it — I won't bring up grocery info unless you ask. You can always change this by saying 'start reminding me about groceries again'."
+2. **Given** Jason has no stored preferences, **When** he sends "no appointment reminders for me", **Then** the bot stores a notification opt-out preference for departure nudges under Jason's phone number and confirms storage.
+3. **Given** Erin has stored preferences, **When** the Docker container restarts, **Then** all of Erin's preferences are loaded from the JSON file on startup and are immediately active.
+4. **Given** Erin sends "check the time before making recommendations", **When** the bot processes the message, **Then** a "communication style" preference is stored indicating the bot should be time-context-aware when making suggestions.
+5. **Given** Erin sends "don't tell me about Jason's appointments", **When** the bot processes the message, **Then** a topic filter preference is stored that excludes Jason's personal calendar from Erin's daily briefings and nudges.
+
+---
+
+### User Story 2 - Honor Stored Preferences (Priority: P1)
+
+Once a preference is stored, the bot actively honors it in all future interactions. Notification opt-outs suppress proactive nudges on that topic. Topic filters remove excluded content from daily briefings and meeting prep. Communication style preferences shape how the bot responds (e.g., time-awareness for recommendations). Preferences are checked both at the system prompt level (injected on each message) and at the nudge delivery level (checked before sending proactive messages).
+
+**Why this priority**: Storing preferences is useless if the bot does not act on them. This is equally critical to US1 — together they form the minimum viable feature. If Erin sets a preference and the bot ignores it, trust erodes further.
+
+**Independent Test**: Store a grocery opt-out preference for Erin. Then trigger a daily briefing for Erin. Verify that the briefing does not include unsolicited grocery or meal plan information. Separately, trigger a nudge scan and verify that grocery-related nudges are filtered out before delivery.
+
+**Acceptance Scenarios**:
+
+1. **Given** Erin has a stored preference "don't remind me about groceries unless I ask", **When** the daily briefing is generated, **Then** the briefing omits unsolicited grocery and meal plan sections. If Erin explicitly asks "what's the meal plan?", the bot responds normally.
+2. **Given** Erin has a stored preference "don't tell me about Jason's appointments", **When** the daily briefing fetches calendar events, **Then** Jason's personal calendar events are excluded from Erin's briefing. Family calendar and Erin's personal calendar are still included.
+3. **Given** Erin has a stored preference "check the time before making recommendations", **When** the bot generates recommendations at 8 AM, **Then** it suggests breakfast/morning-appropriate activities, not dinner plans or bedtime routines.
+4. **Given** Erin has a grocery opt-out preference, **When** the nudge system (`process_pending_nudges`) prepares to send a grocery-related proactive nudge, **Then** the nudge is suppressed (marked as filtered, not sent).
+5. **Given** Erin has a grocery opt-out preference, **When** Erin explicitly asks "what should we have for dinner?", **Then** the bot answers the question normally — opt-outs only suppress unsolicited/proactive messages, not direct requests.
+6. **Given** Jason has no grocery opt-out preference but Erin does, **When** a grocery nudge is scheduled, **Then** Jason still receives the nudge (preferences are per-user, not global).
+
+---
+
+### User Story 3 - List & Manage Preferences (Priority: P2)
+
+Users can ask "what are my preferences?" to see all stored preferences in a readable list. They can remove individual preferences by describing them naturally ("start reminding me about groceries again", "remove the grocery opt-out", "I want Jason's appointments back"). The bot confirms removals and immediately stops applying the removed preference.
+
+**Why this priority**: Users need visibility and control over their preferences. Without this, users cannot audit what preferences are active or correct mistakes. This is important but not as urgent as capture and enforcement — the P1 stories deliver value even if users cannot list preferences yet.
+
+**Independent Test**: Store two preferences for Erin. Send "what are my preferences?" and verify both are listed with human-readable descriptions. Send "start reminding me about groceries again" and verify the grocery preference is removed. Send "what are my preferences?" again and verify only one preference remains.
+
+**Acceptance Scenarios**:
+
+1. **Given** Erin has three stored preferences (grocery opt-out, Jason calendar filter, time-aware recommendations), **When** she sends "what are my preferences?", **Then** the bot responds with a numbered list showing each preference with its description, category, and when it was set.
+2. **Given** Erin has a grocery opt-out preference, **When** she sends "start reminding me about groceries again", **Then** the bot removes the grocery opt-out preference, confirms removal, and immediately resumes including grocery information in proactive messages.
+3. **Given** Erin has a grocery opt-out preference, **When** she sends "remove preference about groceries", **Then** the bot matches "groceries" to the stored preference, removes it, and confirms.
+4. **Given** Erin has no stored preferences, **When** she sends "what are my preferences?", **Then** the bot responds "You don't have any stored preferences. You can set them by telling me things like 'don't remind me about groceries unless I ask' or 'no Jason appointment reminders'."
+5. **Given** Erin has a preference and sends "clear all my preferences", **When** the bot processes the message, **Then** all of Erin's preferences are removed and confirmed.
+
+---
+
+### User Story 4 - Preference Categories (Priority: P3)
+
+Preferences are organized into four categories, enabling the bot to apply them correctly in different contexts:
+
+- **Notification opt-outs**: Suppress proactive nudges for specific topics (groceries, departure reminders, budget alerts). These filter at the nudge delivery layer.
+- **Topic filters**: Exclude specific content from briefings and agendas (Jason's appointments, work calendar, specific budget categories). These filter at the content generation layer.
+- **Communication style**: Shape how the bot generates responses (time-awareness, verbosity, formality, emoji usage). These are injected into the system prompt.
+- **Quiet hours**: Per-user time windows when specific or all proactive messages are suppressed. These filter at the nudge scheduling layer.
+
+**Why this priority**: Categorization improves the bot's ability to apply preferences in the right context (nudge layer vs. system prompt vs. content generation). However, the P1 stories can work with a simpler flat preference list — categorization refines the architecture without adding new user-facing value.
+
+**Independent Test**: Store one preference in each category. Verify that notification opt-outs filter nudges, topic filters modify briefing content, communication style preferences change response tone, and quiet hours suppress messages during specified windows.
+
+**Acceptance Scenarios**:
+
+1. **Given** Erin says "no grocery nudges", **When** the preference is stored, **Then** it is categorized as a "notification opt-out" with the topic "groceries" and is checked at the nudge delivery layer.
+2. **Given** Erin says "don't include Jason's calendar in my daily plan", **When** the preference is stored, **Then** it is categorized as a "topic filter" with the scope "jason_personal_calendar" and is checked during briefing generation.
+3. **Given** Erin says "keep responses short and to the point", **When** the preference is stored, **Then** it is categorized as a "communication style" preference and is injected into the system prompt on each message.
+4. **Given** Erin says "no messages before 8am", **When** the preference is stored, **Then** it is categorized as "quiet hours" with a start time of 8:00 AM Pacific and is checked before any proactive nudge delivery.
+5. **Given** the existing hardcoded budget quiet hours (Rule 67: no budget talk before 8 PM), **When** the preference system is active, **Then** the hardcoded rule continues to work as-is. Migration to a user preference is a future enhancement, not a requirement for this feature.
+
+---
+
+### Edge Cases
+
+- **Conflicting preferences**: Erin says "don't remind me about groceries" and later says "remind me about groceries before each shopping trip." The newer preference replaces the older one for the same topic. The bot confirms: "I updated your grocery preference. I'll now remind you before shopping trips instead of staying quiet about groceries."
+- **Ambiguous preferences**: Erin says "leave me alone." This could mean a temporary DND (like quiet day) or a permanent opt-out. The bot should ask for clarification: "Do you want a quiet day (just for today) or should I stop all proactive messages permanently?" If no clarification is given, default to the less destructive option (quiet day).
+- **Partner-about-partner preferences**: Erin says "don't tell me about Jason's stuff." The bot stores this as a topic filter under Erin's phone number that suppresses Jason-specific content in Erin's messages. It does not affect Jason's experience.
+- **Vague topic matching**: Erin says "stop the budget stuff." The bot should confirm the scope: "I can stop all budget-related proactive messages — budget summaries, spending alerts, goal checks. Should I suppress all of those, or just specific ones?"
+- **Preference persistence during file corruption**: If `user_preferences.json` is corrupted or unreadable on startup, the bot logs a warning and starts with an empty preference set rather than crashing. Preferences set after recovery are saved normally.
+- **Preference overflow**: A user stores an unreasonable number of preferences (50+). The system should cap at a reasonable limit (e.g., 50 per user) and warn the user when approaching the limit.
+- **Implicit vs. explicit preferences**: "I hate when you mention groceries" is an explicit preference to store. "Okay, I'll check on groceries later" is a conversational acknowledgment, not a preference. The bot should only store preferences when the user's intent to set a lasting rule is clear.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect when a user's message contains a lasting preference (opt-out, filter, style, or schedule) and distinguish it from a one-time conversational request.
+- **FR-002**: System MUST store preferences persistently in a JSON file that survives container restarts and redeployment.
+- **FR-003**: System MUST isolate preferences per phone number so that Erin's preferences do not affect Jason's experience and vice versa.
+- **FR-004**: System MUST inject the current user's active preferences into the system prompt on each incoming message so Claude naturally respects them during response generation.
+- **FR-005**: System MUST check stored preferences before delivering any proactive nudge (departure reminders, chore suggestions, grocery nudges, budget alerts) and suppress nudges that match an active opt-out.
+- **FR-006**: System MUST allow users to list all their active preferences via natural language ("what are my preferences?").
+- **FR-007**: System MUST allow users to remove individual preferences via natural language ("start reminding me about groceries again") and immediately stop applying the removed preference.
+- **FR-008**: System MUST handle conflicting preferences by treating the most recent preference for a given topic as authoritative, replacing the older one.
+- **FR-009**: System MUST confirm preference creation and removal with a human-readable message that includes how to reverse the action.
+- **FR-010**: System MUST load preferences from disk on startup and keep the in-memory cache synchronized with the on-disk file after every write.
+- **FR-011**: System MUST use atomic file writes (write-to-tmp-then-rename) to prevent data loss during concurrent access or crashes.
+- **FR-012**: System MUST NOT suppress responses to explicit user requests that match an opted-out topic. Opt-outs only affect proactive/unsolicited messages, not direct questions.
+- **FR-013**: System MUST ask for clarification when a preference statement is ambiguous (e.g., "leave me alone" could mean quiet day or permanent opt-out).
+- **FR-014**: System MUST cap preferences at 50 per user to prevent unbounded storage growth.
+
+### Key Entities
+
+- **User Preference**: A stored rule that modifies the bot's behavior for a specific user. Key attributes: unique identifier, phone number (owner), human-readable label, category (notification opt-out, topic filter, communication style, quiet hours), topic or scope (e.g., "groceries", "jason_personal_calendar"), the original natural language statement, creation timestamp, and active/inactive status.
+- **Preference Category**: One of four classification buckets (notification opt-out, topic filter, communication style, quiet hours) that determines where in the processing pipeline the preference is applied.
+- **Preference Store**: The persistent layer holding all user preferences. Keyed by phone number, supports CRUD operations, atomic writes, and startup loading.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Preferences persist across container restarts — a preference set before restart is active and honored after restart, verified by listing preferences and observing filtered behavior.
+- **SC-002**: Bot honors a stored preference within 1 message of it being set — if Erin sets a grocery opt-out and immediately triggers a daily briefing, the briefing omits grocery content.
+- **SC-003**: Zero false-positive nudges for opted-out topics — after Erin opts out of grocery nudges, no grocery-related proactive messages are sent to her, measured over a 7-day observation period.
+- **SC-004**: Explicit requests override opt-outs 100% of the time — if Erin asks "what's the meal plan?" despite a grocery opt-out, she gets a full answer.
+- **SC-005**: Preference listing is complete and accurate — "what are my preferences?" returns all stored preferences with no omissions and no phantom entries.
+- **SC-006**: Preference removal takes effect immediately — after removing a preference, the very next interaction reflects the removal (e.g., grocery info reappears in the daily briefing).
+- **SC-007**: The three specific preferences Erin has already requested are supported on day one: grocery opt-out, Jason appointment filter, and time-aware recommendations.

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -216,8 +216,8 @@ create_quick_event to add it to the shared family calendar. Format the \
 summary as "Sender → Assignee: task" (e.g., "Erin → Jason: pick up dog"). \
 If it's a self-reminder, use just "Erin: dentist appointment". Include the \
 original message as the event description for context. The event goes on the \
-shared family calendar so both partners can see it. Infer today's date and \
-Pacific time if not specified. Default to a 15-minute popup reminder.
+shared family calendar so both partners can see it. Use the date and time \
+shown at the top of this prompt if not specified. Default to a 15-minute popup reminder.
 
 **Feature discovery & help:**
 37. When someone says "help", "what can you do?", "what are your features?", \
@@ -457,11 +457,11 @@ TOOLS = [
     },
     {
         "name": "complete_action_item",
-        "description": "Mark an action item as done. First call get_action_items to find the page_id of the item to complete, then pass that page_id here.",
+        "description": "Mark an action item as Done. Accepts either a Notion page UUID or the task description text (will fuzzy-match against open items). Prefer using the page_id from get_action_items when available.",
         "input_schema": {
             "type": "object",
             "properties": {
-                "page_id": {"type": "string", "description": "The Notion page ID of the action item to mark as done."},
+                "page_id": {"type": "string", "description": "The Notion page UUID of the action item, or its description text (e.g., 'Call preschool'). UUIDs are preferred — use get_action_items to find them."},
             },
             "required": ["page_id"],
         },
@@ -650,11 +650,11 @@ TOOLS = [
     },
     {
         "name": "complete_backlog_item",
-        "description": "Mark a backlog item as done by its Notion page ID.",
+        "description": "Mark a backlog item as Done. Accepts either a Notion page UUID or the task description text (will fuzzy-match against open items). Prefer using the page_id from get_backlog_items when available.",
         "input_schema": {
             "type": "object",
             "properties": {
-                "page_id": {"type": "string", "description": "The Notion page ID of the backlog item to mark done."},
+                "page_id": {"type": "string", "description": "The Notion page UUID of the backlog item, or its description text. UUIDs are preferred — use get_backlog_items to find them."},
             },
             "required": ["page_id"],
         },
@@ -701,7 +701,7 @@ TOOLS = [
             "type": "object",
             "properties": {
                 "summary": {"type": "string", "description": "Event title. Format as 'Sender → Assignee: task' (e.g., 'Erin → Jason: pick up dog'). If self-reminder, use 'Erin: dentist appointment'."},
-                "start_time": {"type": "string", "description": "ISO datetime (e.g., '2026-02-24T12:30:00-08:00'). Infer today's date if not specified."},
+                "start_time": {"type": "string", "description": "ISO datetime (e.g., '2026-02-24T12:30:00-08:00'). Use the date shown at the top of the system prompt if not specified."},
                 "end_time": {"type": "string", "description": "ISO datetime. Defaults to start + 30 min if omitted."},
                 "description": {"type": "string", "description": "Original message text for context (e.g., 'Erin said: remind Jason to pick up the dog at 12:30')."},
                 "reminder_minutes": {"type": "number", "description": "Minutes before event to send popup reminder. Default 15.", "default": 15},
@@ -1456,9 +1456,11 @@ def handle_message(sender_phone: str, message_text: str, image_data: dict | None
     history_len = len(history)
 
     # Inject current date/time so Claude knows what day it is
+    # P1 fix: place date at BOTH the top and bottom of the system prompt
+    # so the model reliably attends to it (GitHub issue #2)
     now = datetime.now(tz=ZoneInfo("America/Los_Angeles"))
-    date_line = now.strftime("\n\n**Right now:** %A, %B %d, %Y at %I:%M %p Pacific.")
-    system = SYSTEM_PROMPT + date_line
+    date_line = now.strftime("**Right now:** %A, %B %d, %Y at %I:%M %p Pacific.")
+    system = date_line + "\n\n" + SYSTEM_PROMPT + "\n\n" + date_line
 
     # First-time welcome: prepend instruction for new users
     if sender_phone != "system" and sender_phone not in _welcomed_phones:

--- a/src/tools/notion.py
+++ b/src/tools/notion.py
@@ -1,6 +1,7 @@
 """Notion API wrapper — CRUD for action items, meals, meetings, and family profile."""
 
 import logging
+import re
 from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 from notion_client import Client
@@ -26,6 +27,17 @@ notion = Client(auth=NOTION_TOKEN)
 MAX_ROLLOVER_ITEMS = 25          # refuse to roll over more than this
 MAX_TEMPLATE_BLOCK_DELETES = 50  # refuse to delete more template blocks than this
 MAX_PENDING_ORDER_CLEAR = 100    # refuse to clear more pending orders than this
+
+# UUID pattern for Notion page IDs (with or without hyphens)
+_UUID_RE = re.compile(
+    r'^[0-9a-f]{8}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{4}-?[0-9a-f]{12}$',
+    re.IGNORECASE,
+)
+
+
+def _is_notion_uuid(value: str) -> bool:
+    """Check if a string looks like a Notion page UUID."""
+    return bool(_UUID_RE.match(value.strip()))
 
 
 # ---------------------------------------------------------------------------
@@ -113,9 +125,11 @@ def get_action_items(assignee: str = "", status: str = "") -> str:
         assignee_val = _get_select(props.get("Assignee", {}))
         status_val = _get_status(props.get("Status", {}))
         rolled = props.get("Rolled Over", {}).get("checkbox", False)
+        page_id = page["id"]
         items.append(
             f"- {'✅' if status_val == 'Done' else '⬜'} {assignee_val}: {desc}"
             + (" (rolled over)" if rolled else "")
+            + f"  [id:{page_id}]"
         )
     if not items:
         return "No action items found."
@@ -144,7 +158,38 @@ def add_action_item(
 
 
 def complete_action_item(page_id: str) -> str:
-    """Mark an action item as Done by its Notion page ID."""
+    """Mark an action item as Done by its Notion page ID or description text.
+
+    If page_id is not a UUID, fuzzy-matches against open action items by title.
+    """
+    if not _is_notion_uuid(page_id):
+        # Treat page_id as a description — search for a matching action item
+        results = notion.databases.query(
+            database_id=NOTION_ACTION_ITEMS_DB,
+            filter={
+                "property": "Status",
+                "status": {"does_not_equal": "Done"},
+            },
+        )
+        search_lower = page_id.lower().strip()
+        best_match = None
+        best_title = ""
+        for page in results.get("results", []):
+            title_parts = page["properties"].get("Description", {}).get("title", [])
+            title = "".join(t.get("plain_text", "") for t in title_parts)
+            title_lower = title.lower()
+            if search_lower in title_lower or title_lower in search_lower:
+                best_match = page["id"]
+                best_title = title
+                break
+        if not best_match:
+            return (
+                f"Could not find an action item matching '{page_id}'. "
+                "Use get_action_items to find the correct page ID."
+            )
+        logger.info("Fuzzy-matched action item '%s' → %s (%s)", page_id, best_match, best_title)
+        page_id = best_match
+
     notion.pages.update(
         page_id=page_id,
         properties={"Status": {"status": {"name": "Done"}}},
@@ -382,11 +427,13 @@ def get_backlog_items(assignee: str = "", status: str = "") -> str:
         category = _get_select(props.get("Category", {}))
         priority = _get_select(props.get("Priority", {}))
         status_val = _get_status(props.get("Status", {}))
+        page_id = page["id"]
         items.append(
             f"- {'✅' if status_val == 'Done' else '⬜'} {desc}"
             + (f" [{category}]" if category else "")
             + (f" — {priority}" if priority else "")
             + (f" (assigned: {assignee_val})" if assignee_val else "")
+            + f"  [id:{page_id}]"
         )
     if not items:
         return "No backlog items found."
@@ -416,7 +463,40 @@ def add_backlog_item(
 
 
 def complete_backlog_item(page_id: str) -> str:
-    """Mark a backlog item as Done by its Notion page ID."""
+    """Mark a backlog item as Done by its Notion page ID or description text.
+
+    If page_id is not a UUID, fuzzy-matches against open backlog items by title.
+    """
+    if not _is_notion_uuid(page_id):
+        if not NOTION_BACKLOG_DB:
+            return "Backlog database not configured."
+        # Treat page_id as a description — search for a matching backlog item
+        results = notion.databases.query(
+            database_id=NOTION_BACKLOG_DB,
+            filter={
+                "property": "Status",
+                "status": {"does_not_equal": "Done"},
+            },
+        )
+        search_lower = page_id.lower().strip()
+        best_match = None
+        best_title = ""
+        for page in results.get("results", []):
+            title_parts = page["properties"].get("Description", {}).get("title", [])
+            title = "".join(t.get("plain_text", "") for t in title_parts)
+            title_lower = title.lower()
+            if search_lower in title_lower or title_lower in search_lower:
+                best_match = page["id"]
+                best_title = title
+                break
+        if not best_match:
+            return (
+                f"Could not find a backlog item matching '{page_id}'. "
+                "Use get_backlog_items to find the correct page ID."
+            )
+        logger.info("Fuzzy-matched backlog item '%s' → %s (%s)", page_id, best_match, best_title)
+        page_id = best_match
+
     notion.pages.update(
         page_id=page_id,
         properties={"Status": {"status": {"name": "Done"}}},

--- a/src/whatsapp.py
+++ b/src/whatsapp.py
@@ -1,5 +1,6 @@
 """WhatsApp message send/receive helpers via Meta Cloud API."""
 
+import asyncio
 import base64
 import logging
 import httpx
@@ -10,12 +11,14 @@ logger = logging.getLogger(__name__)
 GRAPH_API_URL = f"https://graph.facebook.com/v21.0/{WHATSAPP_PHONE_NUMBER_ID}/messages"
 GRAPH_API_BASE = "https://graph.facebook.com/v21.0"
 MAX_MESSAGE_LENGTH = 1600
+MAX_RETRIES = 3
+RETRY_DELAYS = [1, 2, 4]  # exponential backoff in seconds
 
 
 async def send_message(to: str, text: str) -> None:
     """Send a text message via WhatsApp. Splits long messages automatically."""
     chunks = _split_message(text)
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=10.0)) as client:
         for chunk in chunks:
             payload = {
                 "messaging_product": "whatsapp",
@@ -23,18 +26,27 @@ async def send_message(to: str, text: str) -> None:
                 "type": "text",
                 "text": {"body": chunk},
             }
-            resp = await client.post(
-                GRAPH_API_URL,
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {WHATSAPP_ACCESS_TOKEN}",
-                    "Content-Type": "application/json",
-                },
-            )
-            if resp.status_code == 429:
-                logger.warning("WhatsApp rate limit hit, message may be delayed")
-            elif resp.status_code != 200:
-                logger.error("WhatsApp send failed: %s %s", resp.status_code, resp.text)
+            headers = {
+                "Authorization": f"Bearer {WHATSAPP_ACCESS_TOKEN}",
+                "Content-Type": "application/json",
+            }
+            for attempt in range(MAX_RETRIES):
+                try:
+                    resp = await client.post(GRAPH_API_URL, json=payload, headers=headers)
+                    if resp.status_code == 429:
+                        logger.warning("WhatsApp rate limit hit, retrying after delay")
+                        if attempt < MAX_RETRIES - 1:
+                            await asyncio.sleep(RETRY_DELAYS[attempt])
+                            continue
+                    elif resp.status_code != 200:
+                        logger.error("WhatsApp send failed: %s %s", resp.status_code, resp.text)
+                    break  # Success or non-retryable error
+                except (httpx.ConnectTimeout, httpx.ConnectError, httpx.ReadTimeout) as e:
+                    if attempt < MAX_RETRIES - 1:
+                        logger.warning("WhatsApp send attempt %d failed (%s), retrying in %ds", attempt + 1, type(e).__name__, RETRY_DELAYS[attempt])
+                        await asyncio.sleep(RETRY_DELAYS[attempt])
+                    else:
+                        logger.error("WhatsApp send failed after %d attempts: %s. Message to %s: %s", MAX_RETRIES, e, to, chunk[:200])
 
 
 def _split_message(text: str) -> list[str]:
@@ -86,17 +98,28 @@ async def send_template_message(to: str, template_name: str, parameters: list[st
             "components": components,
         },
     }
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(
-            GRAPH_API_URL,
-            json=payload,
-            headers={
-                "Authorization": f"Bearer {WHATSAPP_ACCESS_TOKEN}",
-                "Content-Type": "application/json",
-            },
-        )
-        if resp.status_code != 200:
-            logger.error("Template message failed: %s %s", resp.status_code, resp.text)
+    headers = {
+        "Authorization": f"Bearer {WHATSAPP_ACCESS_TOKEN}",
+        "Content-Type": "application/json",
+    }
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=10.0)) as client:
+        for attempt in range(MAX_RETRIES):
+            try:
+                resp = await client.post(GRAPH_API_URL, json=payload, headers=headers)
+                if resp.status_code == 429:
+                    logger.warning("WhatsApp template rate limit hit, retrying after delay")
+                    if attempt < MAX_RETRIES - 1:
+                        await asyncio.sleep(RETRY_DELAYS[attempt])
+                        continue
+                elif resp.status_code != 200:
+                    logger.error("Template message failed: %s %s", resp.status_code, resp.text)
+                break  # Success or non-retryable error
+            except (httpx.ConnectTimeout, httpx.ConnectError, httpx.ReadTimeout) as e:
+                if attempt < MAX_RETRIES - 1:
+                    logger.warning("WhatsApp template send attempt %d failed (%s), retrying in %ds", attempt + 1, type(e).__name__, RETRY_DELAYS[attempt])
+                    await asyncio.sleep(RETRY_DELAYS[attempt])
+                else:
+                    logger.error("WhatsApp template send failed after %d attempts: %s. Template: %s to %s", MAX_RETRIES, e, template_name, to)
 
 
 async def send_message_with_template_fallback(
@@ -108,7 +131,7 @@ async def send_message_with_template_fallback(
     is provided, retries with the template message.
     """
     chunks = _split_message(text)
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=httpx.Timeout(15.0, connect=10.0)) as client:
         for chunk in chunks:
             payload = {
                 "messaging_product": "whatsapp",
@@ -116,27 +139,38 @@ async def send_message_with_template_fallback(
                 "type": "text",
                 "text": {"body": chunk},
             }
-            resp = await client.post(
-                GRAPH_API_URL,
-                json=payload,
-                headers={
-                    "Authorization": f"Bearer {WHATSAPP_ACCESS_TOKEN}",
-                    "Content-Type": "application/json",
-                },
-            )
-            if resp.status_code != 200:
-                # Check for "outside service window" error
+            headers = {
+                "Authorization": f"Bearer {WHATSAPP_ACCESS_TOKEN}",
+                "Content-Type": "application/json",
+            }
+            for attempt in range(MAX_RETRIES):
                 try:
-                    err = resp.json()
-                    error_code = err.get("error", {}).get("code", 0)
-                except Exception:
-                    error_code = 0
+                    resp = await client.post(GRAPH_API_URL, json=payload, headers=headers)
+                    if resp.status_code == 429:
+                        logger.warning("WhatsApp rate limit hit, retrying after delay")
+                        if attempt < MAX_RETRIES - 1:
+                            await asyncio.sleep(RETRY_DELAYS[attempt])
+                            continue
+                    elif resp.status_code != 200:
+                        # Check for "outside service window" error
+                        try:
+                            err = resp.json()
+                            error_code = err.get("error", {}).get("code", 0)
+                        except Exception:
+                            error_code = 0
 
-                if error_code == 131026 and template_name:
-                    logger.info("Outside 24h window — falling back to template: %s", template_name)
-                    await send_template_message(to, template_name, template_params)
-                    return
-                logger.error("WhatsApp send failed: %s %s", resp.status_code, resp.text)
+                        if error_code == 131026 and template_name:
+                            logger.info("Outside 24h window — falling back to template: %s", template_name)
+                            await send_template_message(to, template_name, template_params)
+                            return
+                        logger.error("WhatsApp send failed: %s %s", resp.status_code, resp.text)
+                    break  # Success or non-retryable error
+                except (httpx.ConnectTimeout, httpx.ConnectError, httpx.ReadTimeout) as e:
+                    if attempt < MAX_RETRIES - 1:
+                        logger.warning("WhatsApp fallback send attempt %d failed (%s), retrying in %ds", attempt + 1, type(e).__name__, RETRY_DELAYS[attempt])
+                        await asyncio.sleep(RETRY_DELAYS[attempt])
+                    else:
+                        logger.error("WhatsApp fallback send failed after %d attempts: %s. Message to %s: %s", MAX_RETRIES, e, to, chunk[:200])
 
 
 async def download_media(media_id: str) -> tuple[bytes, str]:


### PR DESCRIPTION
## Summary
- **#2** Date/time awareness: inject date at top+bottom of system prompt (Erin corrected bot twice)
- **#3** Action item UUID: fuzzy-match task descriptions when non-UUID passed (was 400 error)
- **#4** WhatsApp retry: 3x backoff on ConnectTimeout (2 messages were silently lost)
- Feature 013 spec: user preference persistence (4 user stories, 14 FRs)

## Test plan
- [ ] Deploy to NUC and verify date line appears correctly in logs
- [ ] Send "I just did [action item]" and verify it marks as done without 400 error
- [ ] Check WhatsApp retry logging on next transient network blip
- [ ] Verify spec completeness for Feature 013

🤖 Generated with [Claude Code](https://claude.com/claude-code)