### PR TITLE
feat: smart daily planner (calendar-aware, confirm-before-write, drive times)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,8 @@ All bash scripts use strict mode (`set -e -u -o pipefail`) and support both git 
 - Atomic JSON file at `data/work_calendar.json` (same pattern as `preferences.py`, `conversation.py`, `routines.py`) (015-ios-work-calendar)
 - Python 3.12 (existing codebase) + anthropic SDK (system prompt construction), datetime/zoneinfo (time injection) (016-time-and-context-fix)
 - Existing `data/conversations.json` (atomic JSON file pattern) (016-time-and-context-fix)
+- Python 3.12 (existing codebase) + FastAPI, anthropic SDK (Claude Haiku 4.5), existing tool functions (017-smart-daily-planner)
+- JSON file at `data/drive_times.json` (same atomic write pattern as `preferences.py`, `routines.py`, `conversation.py`) (017-smart-daily-planner)
 
 ## Deployment (NUC)
 
@@ -113,6 +115,6 @@ All destructive operations have hard caps to prevent accidental mass changes. Th
 | AnyList clear | `src/tools/anylist_bridge.py` | `MAX_ANYLIST_CLEAR` | 150 | Logs warning |
 
 ## Recent Changes
+- 017-smart-daily-planner: Added Python 3.12 (existing codebase) + FastAPI, anthropic SDK (Claude Haiku 4.5), existing tool functions
 - 016-time-and-context-fix: Added Python 3.12 (existing codebase) + anthropic SDK (system prompt construction), datetime/zoneinfo (time injection)
 - 015-ios-work-calendar: Added Python 3.12 (existing codebase) + FastAPI, Pydantic (request model validation), json (stdlib for atomic JSON writes)
-- 012-smart-budget-maintenance: Added Python 3.12 (existing codebase) + FastAPI, anthropic SDK (Claude Opus for tool loop), httpx (YNAB API), existing WhatsApp/n8n infrastructure

--- a/specs/017-smart-daily-planner/checklists/requirements.md
+++ b/specs/017-smart-daily-planner/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Smart Daily Planner
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/017-smart-daily-planner/data-model.md
+++ b/specs/017-smart-daily-planner/data-model.md
@@ -1,0 +1,56 @@
+# Data Model: Smart Daily Planner
+
+**Feature**: 017-smart-daily-planner | **Date**: 2026-03-03
+
+## Entities
+
+### Drive Time Entry
+
+A stored association between a location name and its one-way drive time from home.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| location | string | Human-readable location name (e.g., "gym", "school", "grandma's") |
+| minutes | int | One-way drive time from home in minutes |
+| updated | string (ISO datetime) | When this entry was last added or modified |
+
+**Storage**: `data/drive_times.json`
+
+```json
+{
+  "gym": {"minutes": 5, "updated": "2026-03-03T10:30:00"},
+  "school": {"minutes": 10, "updated": "2026-03-03T10:30:00"},
+  "grandma": {"minutes": 15, "updated": "2026-03-03T10:30:00"},
+  "church": {"minutes": 12, "updated": "2026-03-03T10:30:00"}
+}
+```
+
+**Identity**: Location name (lowercase, normalized). Duplicate location names overwrite the existing entry.
+
+**Lifecycle**: Created when user says "the gym is 5 minutes away." Updated when user says "gym is actually 10 minutes now." Deleted if user requests removal. No automatic expiry.
+
+**Constraints**:
+- Maximum 20 entries (family has <10 common locations, 20 provides headroom)
+- Minutes must be a positive integer (1-120)
+- Location names normalized to lowercase, stripped of articles ("the gym" → "gym")
+
+### Existing Entities (unchanged)
+
+- **Calendar Event**: Already read by `get_daily_context()` via `get_events_for_date()`. No changes needed — events are returned as structured text with times and descriptions.
+- **Daily Plan Draft**: Exists only in chat conversation context. Not persisted anywhere — Claude generates it, presents it, and writes to calendar only after confirmation. No new storage needed.
+
+## Relationships
+
+```
+Drive Time Entry --used-by--> Daily Plan Generation (via system prompt rules)
+Calendar Event (existing) --read-by--> get_daily_context() --feeds--> Daily Plan Generation
+Daily Plan Draft --confirmed--> write_calendar_blocks() --writes--> Google Calendar
+```
+
+## Tools (new)
+
+| Tool Name | Parameters | Returns | Purpose |
+|-----------|-----------|---------|---------|
+| `get_drive_times` | none | JSON string of all drive times | Read during plan generation |
+| `save_drive_time` | location (str), minutes (int) | Confirmation string | Add/update when user mentions a drive time |
+| `delete_drive_time` | location (str) | Confirmation string | Remove a stored drive time |

--- a/specs/017-smart-daily-planner/plan.md
+++ b/specs/017-smart-daily-planner/plan.md
@@ -1,0 +1,79 @@
+# Implementation Plan: Smart Daily Planner
+
+**Branch**: `017-smart-daily-planner` | **Date**: 2026-03-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/017-smart-daily-planner/spec.md`
+
+## Summary
+
+Make the daily plan smarter by: (1) reading existing calendar events and treating them as immovable blocks, (2) presenting a draft plan for Erin's confirmation before writing to calendar, and (3) storing drive times for common locations and auto-inserting travel buffers. This is primarily a **system prompt + drive time storage** change — the calendar data is already available via `get_daily_context()` and the calendar write tool already exists.
+
+## Technical Context
+
+**Language/Version**: Python 3.12 (existing codebase)
+**Primary Dependencies**: FastAPI, anthropic SDK (Claude Haiku 4.5), existing tool functions
+**Storage**: JSON file at `data/drive_times.json` (same atomic write pattern as `preferences.py`, `routines.py`, `conversation.py`)
+**Testing**: Manual verification via WhatsApp + NUC logs
+**Target Platform**: Linux server (Docker on NUC) + WhatsApp interface
+**Project Type**: Web service (existing FastAPI app)
+**Performance Goals**: N/A (same single-user latency)
+**Constraints**: Must work via WhatsApp conversational interface, no new UI
+**Scale/Scope**: Single family, <10 stored drive time locations
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Integration Over Building | ✅ PASS | Uses existing Google Calendar API (read + write). No new services built. |
+| II. Mobile-First Access | ✅ PASS | All interaction via WhatsApp. Confirm/reject is natural conversation ("looks good" / "move gym to 10"). |
+| III. Simplicity & Low Friction | ✅ PASS | Zero new steps for Erin. Calendar events auto-read, drive times auto-inserted, plan confirmation is a simple yes/no reply. Adding drive times via conversation ("the gym is 5 minutes away"). |
+| IV. Structured Output | ✅ PASS | Daily plan output remains structured time blocks with clear formatting. |
+| V. Incremental Value | ✅ PASS | US1 (calendar-aware) works alone. US2 (confirm-before-write) works alone. US3 (drive times) works alone. Each delivers standalone improvement. |
+
+All gates pass. No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/017-smart-daily-planner/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit.tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── assistant.py         # System prompt rules 9-15b (modify rules for US1, US2, US3)
+├── drive_times.py       # NEW — drive time storage module (US3)
+└── context.py           # Minor tweak: include drive times in daily context output
+```
+
+**Structure Decision**: Existing single-project structure. Two files modified (`assistant.py`, `context.py`), one new file (`drive_times.py`) following the same atomic JSON pattern as `preferences.py` and `routines.py`.
+
+## Approach by User Story
+
+### US1: Calendar-Aware Plan Generation
+**Files**: `src/assistant.py` (system prompt only)
+
+The data is already there — `get_daily_context()` reads all 3 Google Calendars and returns events grouped by person. The problem is Claude doesn't treat these as immovable. Fix: add system prompt rules explicitly telling Claude to treat existing calendar events as fixed blocks, schedule new activities around them, and never overlap or omit them.
+
+### US2: Confirm Before Writing to Calendar
+**Files**: `src/assistant.py` (system prompt only)
+
+Currently rule 14 says: "After generating the plan, write time blocks to Erin's Google Calendar." Change this to: present the plan as a draft, ask for confirmation, only write after explicit approval. This is a pure prompt behavior change — the `write_calendar_blocks` tool already exists and Claude already decides when to call it.
+
+### US3: Drive Time Buffers
+**Files**: `src/drive_times.py` (new), `src/assistant.py` (new tool + rules), `src/context.py` (include drive times in context)
+
+New module `drive_times.py` stores location→minutes mappings in `data/drive_times.json`. Two new tools exposed to Claude: `get_drive_times` (read all stored times) and `save_drive_time` (add/update a location). System prompt rules instruct Claude to call `get_drive_times` during plan generation and insert travel buffers.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/017-smart-daily-planner/quickstart.md
+++ b/specs/017-smart-daily-planner/quickstart.md
@@ -1,0 +1,152 @@
+# Quickstart Verification: Smart Daily Planner
+
+**Feature**: 017-smart-daily-planner | **Date**: 2026-03-03
+
+## Prerequisites
+
+- Server running locally or on NUC
+- Erin's Google Calendar has events for today (including recurring events like school drop-off/pickup)
+- WhatsApp or direct API access for testing
+
+---
+
+## Scenario 1: Calendar events appear as fixed blocks (US1)
+
+**Setup**: Ensure Vienna's school drop-off (9:00 AM) and pickup (3:00 PM) are on Erin's calendar for a weekday.
+
+**Steps**:
+1. Send "plan my day" via WhatsApp
+2. Verify the response includes school drop-off and pickup as fixed blocks
+3. Verify other activities are scheduled around them (not overlapping)
+
+**Expected**: Plan shows drop-off and pickup without Erin mentioning them. No activities overlap with these time blocks.
+
+---
+
+## Scenario 2: Recurring events auto-included (US1)
+
+**Setup**: Ensure a recurring weekly event (e.g., swim lesson Monday 4 PM) is on the calendar.
+
+**Steps**:
+1. Send "plan my Monday" on a day when the recurring event is active
+2. Verify the recurring event appears in the plan
+
+**Expected**: Swim lesson (or other recurring event) appears automatically.
+
+---
+
+## Scenario 3: Draft presented before calendar write (US2)
+
+**Steps**:
+1. Send "plan my day"
+2. Verify the bot presents the plan as a draft with a confirmation prompt
+3. Verify NO calendar events were created at this point
+
+**Expected**: Bot shows plan and asks something like "Want me to add this to your calendar?" No calendar writes yet.
+
+---
+
+## Scenario 4: Plan modification before confirmation (US2)
+
+**Steps**:
+1. Send "plan my day" → bot shows draft
+2. Send "move gym to 10 AM"
+3. Verify bot shows updated draft, asks for confirmation again
+4. Send "looks good"
+5. Verify calendar blocks are now written
+
+**Expected**: Calendar blocks written only after "looks good." Only one set of calendar entries (not multiple from revisions).
+
+---
+
+## Scenario 5: Rejection skips calendar write (US2)
+
+**Steps**:
+1. Send "plan my day" → bot shows draft
+2. Send "never mind" or "skip the calendar"
+3. Verify NO calendar events were created
+
+**Expected**: Plan visible in chat but no calendar writes.
+
+---
+
+## Scenario 6: Morning briefing does not auto-write (US2)
+
+**Steps**:
+1. Trigger the morning briefing (n8n 7 AM trigger or manual API call)
+2. Verify the plan is presented as a draft
+3. Verify NO calendar events were created until Erin confirms
+
+**Expected**: Morning briefing shows plan, waits for WhatsApp reply before writing.
+
+---
+
+## Scenario 7: Drive times auto-included in plan (US3)
+
+**Setup**: Store drive times: `save_drive_time("gym", 5)` and `save_drive_time("school", 10)`.
+
+**Steps**:
+1. Send "plan my day" with gym and school pickup in the plan
+2. Verify drive time buffers appear between activities at different locations
+
+**Expected**: 5-minute buffer before gym activities, 10-minute buffer before school activities. No buffer between consecutive home activities.
+
+---
+
+## Scenario 8: Add drive time via conversation (US3)
+
+**Steps**:
+1. Send "the park is 15 minutes away"
+2. Verify bot confirms the drive time was saved
+3. Send "plan my Saturday" with a park visit
+4. Verify 15-minute buffer appears for the park
+
+**Expected**: Drive time stored persistently and used in future plans.
+
+---
+
+## Scenario 9: Update existing drive time (US3)
+
+**Steps**:
+1. Send "gym is actually 10 minutes now"
+2. Verify bot confirms the update
+3. Check `data/drive_times.json` — gym should show 10 minutes
+
+**Expected**: Existing entry updated, not duplicated.
+
+---
+
+## Scenario 10: No buffer for unknown locations (US3)
+
+**Steps**:
+1. Send "plan my day" with an activity at a location with no stored drive time
+2. Verify plan is generated without a buffer for that location
+
+**Expected**: No error, no prompt to add drive time. Plan generated smoothly.
+
+---
+
+## Scenario 11: Plan a future day (Edge Case)
+
+**Steps**:
+1. Send "plan my Wednesday" (when today is not Wednesday)
+2. Verify bot reads Wednesday's calendar events
+3. Verify draft confirmation flow still applies
+
+**Expected**: Wednesday's events shown, confirmation required before calendar write.
+
+---
+
+## Verification Checklist
+
+- [ ] Existing calendar events appear as fixed blocks in daily plans
+- [ ] Recurring events auto-included without user mentioning them
+- [ ] Plans presented as drafts before calendar writes
+- [ ] Modifications re-present draft without writing to calendar
+- [ ] "Never mind" / rejection skips calendar write
+- [ ] Morning briefing does not auto-write to calendar
+- [ ] Stored drive times create travel buffers in plans
+- [ ] Drive times can be added via conversation
+- [ ] Drive times can be updated via conversation
+- [ ] No errors when location has no stored drive time
+- [ ] Future day planning reads correct calendar events

--- a/specs/017-smart-daily-planner/research.md
+++ b/specs/017-smart-daily-planner/research.md
@@ -1,0 +1,51 @@
+# Research: Smart Daily Planner
+
+**Feature**: 017-smart-daily-planner | **Date**: 2026-03-03
+
+## R1: How to make Claude treat existing calendar events as immovable blocks
+
+**Decision**: System prompt rules only — no code changes needed for calendar reading.
+
+**Rationale**: `get_daily_context()` in `src/context.py` already reads all 3 Google Calendars (Jason personal, Erin personal, Family shared) via `get_events_for_date()` and returns structured text with event times and descriptions. The function also handles recurring events (they appear on the calendar like any other event). The issue is that Claude's current system prompt (rules 9-15b) doesn't explicitly instruct it to treat these events as fixed/immovable when generating a plan. Adding explicit rules ("treat existing calendar events as fixed blocks that cannot be moved or overlapped") will fix this without any code changes.
+
+**Alternatives considered**:
+- Modify `get_daily_context()` to return events with a `[FIXED]` tag — rejected because the problem is prompt behavior, not data formatting. Adding tags is unnecessary complexity.
+- Pre-process calendar events into a structured plan template before Claude sees them — rejected because Claude is already good at working with structured text when given clear instructions.
+
+## R2: Confirm-before-write pattern
+
+**Decision**: Modify system prompt rule 14 to present draft → wait for confirmation → only then call `write_calendar_blocks`.
+
+**Rationale**: The `write_calendar_blocks` tool is already a separate tool call that Claude decides to invoke. Currently rule 14 instructs Claude to call it immediately after generating the plan. Changing the rule to "present as draft, ask for confirmation" means Claude will hold off on the tool call until the user says "yes" / "looks good" / "add it." This is pure prompt engineering — no code changes to the tool or the message handler. The morning briefing (n8n trigger) uses the same flow, so the rule also needs to specify: never auto-write from the briefing, always wait for WhatsApp confirmation.
+
+**Alternatives considered**:
+- Add a `draft_plan` intermediate storage mechanism — rejected because the plan exists in chat context. Claude can reference it when the user confirms and then call `write_calendar_blocks`.
+- Add a confirmation modal/UI — rejected because WhatsApp is the interface and natural conversation ("looks good") is simpler.
+
+## R3: Drive time storage approach
+
+**Decision**: New `src/drive_times.py` module with atomic JSON file at `data/drive_times.json`.
+
+**Rationale**: The project has an established pattern for small persistent data: in-memory dict + atomic JSON writes (see `preferences.py`, `routines.py`, `conversation.py`). Drive times are a simple key-value mapping (location name → minutes from home). Maximum ~10 entries. The pattern works perfectly:
+- `get_drive_times()` → returns all stored drive times
+- `save_drive_time(location, minutes)` → add or update
+- `delete_drive_time(location)` → remove
+
+Two new tools registered in `assistant.py` so Claude can read/write drive times.
+
+**Alternatives considered**:
+- Store in Notion Family Profile page — rejected because it requires API calls for simple key-value data, adds latency, and the page structure is complex. Local JSON is faster and simpler.
+- Store in user preferences (`preferences.py`) — rejected because drive times are family-level data (not per-phone-number) and the preferences module is structured around categories/descriptions, not simple key-value pairs.
+- Store in a dedicated Notion database — rejected per Constitution I (Integration Over Building) and III (Simplicity). A JSON file for <10 entries is the right tool.
+
+## R4: How to include drive times in daily context
+
+**Decision**: Add `get_drive_times` call to `get_daily_context()` output and reference it in system prompt rules.
+
+**Rationale**: When Claude generates a plan, it calls `get_daily_context` which returns calendar events, childcare status, etc. Including drive times in this output means Claude sees them at plan time without needing a separate tool call. However, Claude also needs a separate `save_drive_time` tool for when Erin says "the gym is 5 minutes away" in normal conversation. So: drive times appear in context output (for automatic use during planning) AND as dedicated tools (for add/update/delete).
+
+## R5: Morning briefing behavior
+
+**Decision**: System prompt rule covers this — the morning briefing (n8n trigger) generates a plan but does NOT auto-write to calendar.
+
+**Rationale**: The morning briefing comes through the same `handle_message` endpoint as regular WhatsApp messages. The system prompt will instruct Claude: "When generating a daily plan from the morning briefing or any automated trigger, present the plan as a draft and wait for the user to confirm before writing to calendar." This matches the confirm-before-write pattern from US2 and requires no code changes to n8n or the webhook handler.

--- a/specs/017-smart-daily-planner/spec.md
+++ b/specs/017-smart-daily-planner/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: Smart Daily Planner
+
+**Feature Branch**: `017-smart-daily-planner`
+**Created**: 2026-03-03
+**Status**: Draft
+**Input**: User description: "Smarter daily planning — school schedule awareness, drive times, confirm-then-write"
+**Related**: GitHub Issue #21
+
+## Context
+
+The daily plan is Erin's #1 interaction with the bot. She asks for a plan almost every morning, and the bot generates a schedule with time blocks written to her Google Calendar. Currently, this process is frustrating because:
+
+1. **The bot forgets recurring obligations** — Vienna's school drop-off (9-9:15 AM) and pickup (3-3:45 PM) are already on the calendar, but the bot doesn't account for them when building the plan. Erin has to correct it every time.
+2. **No travel time awareness** — Erin had to manually tell the bot "the gym has a 5 minute drive time." Common locations have predictable drive times that should be stored and automatically included.
+3. **Calendar writes happen before confirmation** — The bot generates a plan and immediately writes it to Google Calendar. When Erin requests changes (which she almost always does), the bot rewrites the calendar blocks, sometimes 3+ times in one session. This clutters her calendar with stale entries.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Calendar-Aware Plan Generation (Priority: P1)
+
+When Erin asks for a daily plan, the bot automatically reads all of her existing calendar events (including recurring ones like school drop-off/pickup, swim lessons, appointments) and builds the plan around them. She never has to remind the bot about events that are already on her calendar.
+
+**Why this priority**: This is the most frequent pain point — Erin corrects the plan for school times virtually every session. Reading existing calendar events is the foundation that makes the other improvements possible.
+
+**Independent Test**: Ask "plan my day" on a weekday with Vienna's school events on the calendar. The plan should include drop-off and pickup blocks without being told.
+
+**Acceptance Scenarios**:
+
+1. **Given** Vienna's school drop-off (9:00 AM) and pickup (3:00 PM) are on Erin's Google Calendar, **When** Erin asks "plan my day," **Then** the plan includes these events as fixed blocks and schedules other activities around them.
+2. **Given** Erin has a doctor appointment at 2:00 PM on her calendar, **When** she asks for a daily plan, **Then** the plan shows the appointment as a fixed block and doesn't schedule anything over it.
+3. **Given** there are no calendar events for the day, **When** Erin asks for a plan, **Then** the bot generates a plan with open blocks and notes that the calendar is clear.
+4. **Given** a recurring weekly event (e.g., swim Monday 4 PM), **When** Erin asks for Monday's plan, **Then** swim appears automatically without Erin mentioning it.
+
+---
+
+### User Story 2 - Confirm Before Writing to Calendar (Priority: P1)
+
+The bot presents a draft daily plan for Erin to review before writing anything to her calendar. Erin can request changes (add items, remove items, adjust times), and only when she approves does the bot write the final version to the calendar.
+
+**Why this priority**: The current behavior of immediately writing to calendar causes clutter when the plan needs revisions (which is almost every time). This is co-P1 with US1 because together they eliminate the most friction.
+
+**Independent Test**: Ask "plan my day," review the draft, request one change, approve, and verify only the final version appears on the calendar.
+
+**Acceptance Scenarios**:
+
+1. **Given** Erin asks "plan my day," **When** the bot generates the plan, **Then** it presents the plan as a draft and asks "Want me to add this to your calendar?" (or similar confirmation).
+2. **Given** Erin reviews the draft and says "move gym to 10 AM," **When** the bot adjusts, **Then** it shows the updated plan and asks for confirmation again — no calendar writes yet.
+3. **Given** Erin says "looks good" or "yes" or "add it," **When** the bot writes to calendar, **Then** it confirms with the number of blocks written and they appear in her Apple Calendar.
+4. **Given** Erin says "never mind" or "skip the calendar," **When** the bot responds, **Then** no calendar writes happen but she still has the plan in chat.
+5. **Given** the morning automated briefing (triggered at 7 AM), **When** the system generates a daily plan, **Then** it does NOT auto-write to calendar — it presents the plan and waits for Erin to confirm via WhatsApp reply.
+
+---
+
+### User Story 3 - Drive Time Buffers (Priority: P2)
+
+The bot knows how long it takes to drive to common destinations (school, gym, grandma's, church, etc.) and automatically adds travel buffers between activities at different locations. When Erin adds a new location, she can tell the bot the drive time once and it remembers for future plans.
+
+**Why this priority**: Drive times are important for realistic scheduling, but the bot can still generate useful plans without them (just less accurate). This builds on US1's calendar-aware planning.
+
+**Independent Test**: Ask for a plan that includes the gym and school pickup — the plan should include 5-minute drive times between home, gym, and school without being told.
+
+**Acceptance Scenarios**:
+
+1. **Given** the family profile has stored drive times (gym: 5 min, school: 10 min), **When** Erin's plan includes gym at 9:15 AM, **Then** the plan shows a drive-to-gym buffer before it.
+2. **Given** Erin says "the park is 15 minutes away," **When** she asks for a plan later that includes the park, **Then** the 15-minute drive time is automatically included.
+3. **Given** two consecutive activities are at the same location (e.g., both at home), **When** the plan is generated, **Then** no drive time buffer is added between them.
+4. **Given** no drive time is stored for a location, **When** the plan includes that location, **Then** the bot generates the plan without a buffer rather than asking (zero friction).
+
+---
+
+### Edge Cases
+
+- What happens when Erin asks to plan a future day (e.g., "plan my Wednesday")? The bot should read Wednesday's calendar events and generate a plan for that day, still requiring confirmation before writing.
+- What happens when existing calendar events overlap with each other? The bot should flag the conflict and ask Erin how to handle it.
+- What happens when Erin wants to modify a plan that was already written to calendar? The bot should update/delete the old blocks and write the new ones (after confirmation).
+- What happens when the calendar is unreachable? The bot should generate the plan from what it knows (backlog, routines) and skip the calendar read, noting the issue.
+- What happens when Erin says a drive time has changed (e.g., "gym is actually 10 minutes now")? The stored drive time should be updated.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: When generating a daily plan, the system MUST read the user's existing calendar events for that day and treat them as fixed, immovable blocks.
+- **FR-002**: The system MUST identify recurring events (school, activities, appointments) from the calendar and include them in every relevant plan without the user specifying them.
+- **FR-003**: The system MUST present daily plans as drafts for user review before writing any events to the calendar.
+- **FR-004**: The system MUST wait for explicit user confirmation (e.g., "yes," "looks good," "add it") before writing plan blocks to the calendar.
+- **FR-005**: The system MUST allow the user to request modifications to the draft plan (add, remove, adjust times) and re-present the updated draft.
+- **FR-006**: The system MUST store drive times for commonly visited locations so they persist across sessions.
+- **FR-007**: When generating a plan with activities at different locations, the system MUST automatically insert travel buffers using stored drive times.
+- **FR-008**: Users MUST be able to add or update drive times for locations through natural conversation (e.g., "the gym is 5 minutes away").
+- **FR-009**: If no drive time is stored for a location, the system MUST generate the plan without a buffer rather than asking.
+- **FR-010**: The automated morning briefing MUST present the plan as a draft, not auto-write to calendar.
+
+### Key Entities
+
+- **Daily Plan Draft**: A proposed schedule for a specific day, including fixed calendar events, planned activities, and travel buffers. Exists in chat until confirmed.
+- **Drive Time Entry**: A stored association between a location name and its one-way drive time from home. Persists in the family profile.
+- **Calendar Event (existing)**: Events already on the user's Google Calendar, treated as immovable blocks during plan generation.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Erin's daily plan includes school drop-off and pickup times on the first attempt in 100% of weekday plans (zero corrections needed for calendar events).
+- **SC-002**: Plan revision cycles drop from 3+ per session to 1 or fewer (Erin confirms or requests one tweak).
+- **SC-003**: Calendar blocks are only written once per planning session (no duplicate/stale entries from multiple rewrites).
+- **SC-004**: Drive times for stored locations appear automatically in plans without Erin mentioning them.
+
+## Assumptions
+
+- Erin's existing calendar events (school, appointments, activities) are reliably on her Google Calendar before she asks for a plan.
+- The family has fewer than 10 commonly visited locations with stored drive times.
+- Drive times are one-way from home (the family lives in one location and drives out to activities).
+- Erin will naturally say "looks good" or similar when approving a plan — no new UI or special commands needed.
+- The n8n morning briefing (7 AM) triggers the same plan generation but skips auto-writing to calendar.
+
+## Out of Scope
+
+- Real-time traffic or route-based drive time estimation — stored static values are sufficient for a small city like Reno.
+- Multi-stop trip optimization (e.g., "go to gym then UPS then school") — the plan is sequential, not route-optimized.
+- Automatic detection of new locations from calendar events — Erin adds drive times manually when she wants them.
+- Plan templates or saved plan patterns — each day is generated fresh from calendar + preferences.

--- a/specs/017-smart-daily-planner/tasks.md
+++ b/specs/017-smart-daily-planner/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: Smart Daily Planner
+
+**Input**: Design documents from `/specs/017-smart-daily-planner/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new dependencies needed. Only US3 requires a new file — setup is minimal.
+
+*(No setup tasks — existing Python 3.12 + FastAPI project. US3's new file is created within its story phase.)*
+
+---
+
+## Phase 2: User Story 1 — Calendar-Aware Plan Generation (Priority: P1) MVP
+
+**Goal**: Claude treats existing calendar events (including recurring ones) as fixed, immovable blocks when generating daily plans. Erin never has to remind the bot about events already on her calendar.
+
+**Independent Test**: Ask "plan my day" on a weekday with Vienna's school events on the calendar. The plan should include drop-off and pickup blocks without being told.
+
+### Implementation for User Story 1
+
+- [x] T001 [US1] Add calendar-aware planning rules to SYSTEM_PROMPT in src/assistant.py. After rule 9 (which calls get_daily_context), add new rules: "**Calendar-aware planning (CRITICAL):** 9a. When generating a daily plan, the calendar events returned by get_daily_context are **FIXED, IMMOVABLE blocks**. NEVER omit them, move them, or schedule activities that overlap with them. These include recurring events (school drop-off, swim lessons, appointments) — they appear automatically from the calendar. 9b. Build the plan AROUND existing calendar events. First lay out all fixed blocks from the calendar, then fill remaining open time slots with planned activities, backlog items, and routines. 9c. If existing calendar events overlap with each other, flag the conflict to Erin and ask how she wants to handle it. 9d. If the calendar is unreachable, generate the plan from backlog and routines, noting that calendar events could not be loaded."
+- [x] T002 [US1] Verify calendar-aware rules: read src/assistant.py and confirm the new rules 9a-9d are present after rule 9. Check that get_daily_context already returns calendar events from all 3 calendars (Jason, Erin, Family) by reading src/context.py get_daily_context function.
+
+**Checkpoint**: Claude now treats existing calendar events as immovable blocks. School drop-off/pickup appear automatically in plans.
+
+---
+
+## Phase 3: User Story 2 — Confirm Before Writing to Calendar (Priority: P1)
+
+**Goal**: The bot presents a draft plan and waits for explicit confirmation before writing to Google Calendar. No more 3+ calendar rewrites per session.
+
+**Independent Test**: Ask "plan my day," review the draft, request one change, approve, and verify only the final version appears on the calendar.
+
+**Depends on**: No hard dependency on US1 (different rules), but best implemented after US1 since they modify the same section of the system prompt.
+
+### Implementation for User Story 2
+
+- [x] T003 [US2] Replace rule 14 in SYSTEM_PROMPT in src/assistant.py. Change the current rule 14 ("After generating the plan, write time blocks to Erin's Google Calendar using write_calendar_blocks so they appear in her Apple Calendar with push notifications") to: "**Confirm before writing (CRITICAL):** 14. After generating the daily plan, present it as a **DRAFT** for review. Say something like 'Here's your plan — want me to add it to your calendar?' or 'Ready to write this to your calendar?' 14a. Do NOT call write_calendar_blocks until Erin explicitly confirms (e.g., 'yes,' 'looks good,' 'add it,' 'write it'). 14b. If Erin requests changes ('move gym to 10 AM,' 'add a walk at 2,' 'remove the laundry block'), adjust the plan and re-present the updated draft. Ask for confirmation again. 14c. If Erin declines ('never mind,' 'skip the calendar,' 'no'), do NOT write to calendar. She still has the plan in chat. 14d. When triggered by the automated morning briefing (7 AM n8n), ALWAYS present the plan as a draft — never auto-write. Wait for Erin's WhatsApp reply to confirm. 14e. When writing to calendar after confirmation, report the number of blocks written (e.g., 'Done! Wrote 6 blocks to your calendar.')."
+- [x] T004 [US2] Verify confirm-before-write rules: read src/assistant.py and confirm rule 14 has been replaced with the draft-then-confirm pattern (rules 14, 14a-14e). Confirm the old auto-write language is gone.
+
+**Checkpoint**: Plans are presented as drafts. Calendar writes only happen after Erin says "yes." Morning briefing also waits for confirmation.
+
+---
+
+## Phase 4: User Story 3 — Drive Time Buffers (Priority: P2)
+
+**Goal**: The bot knows drive times to common destinations and automatically adds travel buffers between activities at different locations.
+
+**Independent Test**: Ask for a plan that includes the gym and school pickup — the plan should include 5-minute and 10-minute drive times without being told.
+
+**Depends on**: Independent of US1 and US2 (different files + separate rules). Can run in parallel.
+
+### Implementation for User Story 3
+
+- [x] T005 [P] [US3] Create src/drive_times.py — drive time storage module. Follow the same pattern as src/routines.py (in-memory dict + atomic JSON writes to data/drive_times.json). Implement: (1) `_load_drive_times()` — load from JSON on module init, (2) `_save_drive_times()` — atomic write (write .tmp then rename), (3) `get_drive_times() -> str` — return all stored drive times as formatted string for Claude, (4) `save_drive_time(location: str, minutes: int) -> str` — add or update a drive time entry (normalize location to lowercase, validate minutes 1-120, cap at 20 entries), (5) `delete_drive_time(location: str) -> str` — remove a stored drive time. Storage format: `{"gym": {"minutes": 5, "updated": "ISO"}, ...}`.
+- [x] T006 [US3] Register drive time tools in src/assistant.py. Add 3 new tools to the tools list: (1) `get_drive_times` — no parameters, returns all stored drive times, (2) `save_drive_time` — parameters: location (string), minutes (integer), (3) `delete_drive_time` — parameter: location (string). Add handler functions `_handle_get_drive_times`, `_handle_save_drive_time`, `_handle_delete_drive_time` that call the corresponding functions from src/drive_times.py. Add entries to the TOOL_HANDLERS dict.
+- [x] T007 [US3] Add drive time rules to SYSTEM_PROMPT in src/assistant.py. After rule 15b (routines), add: "**Drive time buffers:** 15c. When generating a daily plan, call get_drive_times to check for stored travel times. If the plan includes activities at different locations, automatically insert travel buffer blocks (e.g., '🚗 Drive to gym — 5 min') between activities at different locations. 15d. If two consecutive activities are at the same location (e.g., both at home), do NOT add a drive buffer between them. 15e. If no drive time is stored for a location, generate the plan without a buffer for that location — do not ask. 15f. When a user mentions a drive time in conversation (e.g., 'the park is 15 minutes away,' 'gym is actually 10 minutes now'), call save_drive_time to store or update it. Confirm what was saved."
+- [x] T008 [US3] Add drive times to daily context output in src/context.py. In the `get_daily_context()` function, after the calendar events section and before the return, import and call `get_drive_times()` from `src.drive_times` and append the result to the context string under a "Drive times" header. This way Claude sees drive times automatically during plan generation without needing a separate tool call.
+- [x] T009 [US3] Verify drive time module: read src/drive_times.py and confirm it follows the atomic JSON pattern. Read src/assistant.py and confirm the 3 new tools are registered with handlers. Read src/context.py and confirm drive times are included in daily context output.
+
+**Checkpoint**: Drive times stored persistently. Travel buffers auto-inserted in plans. Erin can add/update drive times via conversation.
+
+---
+
+## Phase 5: Polish & Deployment
+
+**Purpose**: Deploy, validate end-to-end, and close GitHub issue.
+
+- [ ] T010 Commit all changes, push to branch `017-smart-daily-planner`, create PR, and deploy to NUC via `./scripts/nuc.sh deploy`.
+- [ ] T011 Run quickstart.md Scenarios 1-2 (calendar-aware planning) against production: send "plan my day" on a weekday with school events on the calendar, verify drop-off and pickup appear as fixed blocks.
+- [ ] T012 Run quickstart.md Scenarios 3-5 (confirm-before-write) against production: send "plan my day," verify draft is presented, request a change, approve, verify calendar blocks written only once.
+- [ ] T013 Run quickstart.md Scenarios 7-10 (drive times) against production: store a drive time via conversation, request a plan with that location, verify buffer appears.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: N/A — no setup needed
+- **US1 (Phase 2)**: T001-T002 — system prompt rules in src/assistant.py
+- **US2 (Phase 3)**: T003-T004 — system prompt rules in src/assistant.py (same file as US1, different rules)
+- **US3 (Phase 4)**: T005-T009 — new file src/drive_times.py + rules in src/assistant.py + context.py update
+- **Polish (Phase 5)**: T010-T013 — depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent. Adds rules 9a-9d to src/assistant.py.
+- **US2 (P1)**: Independent of US1 functionally, but modifies same file (src/assistant.py). Best done sequentially after US1 to avoid merge conflicts.
+- **US3 (P2)**: Independent. Creates new file src/drive_times.py. T006-T007 modify src/assistant.py (same file as US1/US2), so best done after US1/US2.
+
+### Parallel Opportunities
+
+- T005 (new file) can run in parallel with T001-T004 (different file)
+- T001 and T003 are sequential (same file, same area)
+- T006, T007, T008 are sequential with each other and with US1/US2 tasks (shared files)
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 + US2)
+
+1. Complete T001-T002 (calendar-aware rules)
+2. Complete T003-T004 (confirm-before-write rules)
+3. **STOP and VALIDATE**: Deploy and test with Erin — these two changes eliminate 90% of the friction
+4. Deploy if ready — Erin immediately gets better planning
+
+### Incremental Delivery
+
+1. T001-T002 → US1 complete → Calendar events are fixed blocks
+2. T003-T004 → US2 complete → Draft-then-confirm pattern works
+3. T005-T009 → US3 complete → Drive time buffers auto-inserted
+4. T010-T013 → Deployed and validated on NUC
+
+---
+
+## Notes
+
+- Total: 13 tasks
+- US1: 2 tasks (system prompt only)
+- US2: 2 tasks (system prompt only)
+- US3: 5 tasks (new module + tools + rules + context integration)
+- Polish: 4 tasks (deploy + validation)
+- Primary change is system prompt rules in src/assistant.py (~30 lines of prompt text)
+- One new file: src/drive_times.py (~80 lines, following routines.py pattern)
+- One small edit to src/context.py (append drive times to context output)
+- Closes GitHub Issue #21 (Smarter daily planning)

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -12,6 +12,7 @@ from src import conversation
 from src import preferences
 from src import context
 from src import routines
+from src import drive_times
 
 logger = logging.getLogger(__name__)
 
@@ -81,6 +82,18 @@ by the morning briefing):
 or recommendation interaction. This returns today's calendar events grouped by \
 person, childcare status (who has Zoey), communication mode, active preferences, \
 and pending backlog count. Do NOT call for simple factual questions.
+**Calendar-aware planning (CRITICAL — GitHub issue #21):**
+9a. When generating a daily plan, the calendar events returned by get_daily_context \
+are **FIXED, IMMOVABLE blocks**. NEVER omit them, move them, or schedule activities \
+that overlap with them. These include recurring events (school drop-off, swim lessons, \
+appointments) — they appear automatically from the calendar.
+9b. Build the plan AROUND existing calendar events. First lay out all fixed blocks \
+from the calendar, then fill remaining open time slots with planned activities, \
+backlog items, and routines.
+9c. If existing calendar events overlap with each other, flag the conflict to Erin \
+and ask how she wants to handle it.
+9d. If the calendar is unreachable, generate the plan from backlog and routines, \
+noting that calendar events could not be loaded.
 10. Use the output from get_daily_context to determine who has Zoey today, what \
 activities are scheduled per person, and what time-of-day communication mode to \
 use. The tool infers childcare from calendar event keywords — no hardcoded \
@@ -114,9 +127,21 @@ work on?", ALWAYS call get_backlog_items first and suggest the best-fit item \
 for the available time. Prioritize: (a) time-sensitive items first (calls to \
 make, appointments to schedule), (b) quick one-off tasks, (c) recurring/ongoing \
 projects. Never give vague suggestions when the backlog has real items.
-14. After generating the plan, write time blocks to Erin's Google Calendar \
-using write_calendar_blocks so they appear in her Apple Calendar with push \
-notifications
+**Confirm before writing (CRITICAL — GitHub issue #21):**
+14. After generating the daily plan, present it as a **DRAFT** for review. Say \
+something like "Here's your plan — want me to add it to your calendar?" or \
+"Ready to write this to your calendar?"
+14a. Do NOT call write_calendar_blocks until Erin explicitly confirms (e.g., \
+"yes," "looks good," "add it," "write it").
+14b. If Erin requests changes ("move gym to 10 AM," "add a walk at 2," "remove \
+the laundry block"), adjust the plan and re-present the updated draft. Ask for \
+confirmation again.
+14c. If Erin declines ("never mind," "skip the calendar," "no"), do NOT write \
+to calendar. She still has the plan in chat.
+14d. When triggered by the automated morning briefing (7 AM n8n), ALWAYS present \
+the plan as a draft — never auto-write. Wait for Erin's WhatsApp reply to confirm.
+14e. When writing to calendar after confirmation, report the number of blocks \
+written (e.g., "Done! Wrote 6 blocks to your calendar.").
 15. Recurring activities (chores, gym, rest) are just calendar blocks for \
 structure — no check-in needed. One-off backlog items get followed up at \
 the weekly meeting.
@@ -130,6 +155,18 @@ read-modify-save pattern: call get_routine to get current steps, modify the \
 list per the user's instruction (insert, remove, or reorder), then call \
 save_routine with the updated steps. For routine deletion ("delete my morning \
 routine"), call delete_routine directly.
+**Drive time buffers (GitHub issue #21):**
+15c. When generating a daily plan, call get_drive_times to check for stored \
+travel times. If the plan includes activities at different locations, \
+automatically insert travel buffer blocks (e.g., "🚗 Drive to gym — 5 min") \
+between activities at different locations.
+15d. If two consecutive activities are at the same location (e.g., both at \
+home), do NOT add a drive buffer between them.
+15e. If no drive time is stored for a location, generate the plan without a \
+buffer for that location — do not ask.
+15f. When a user mentions a drive time in conversation (e.g., "the park is \
+15 minutes away," "gym is actually 10 minutes now"), call save_drive_time \
+to store or update it. Confirm what was saved.
 
 **Childcare context overrides:**
 16. If a partner says "mom isn't taking Zoey today" or "grandma has Zoey \
@@ -1211,6 +1248,47 @@ TOOLS = [
             "required": ["name"],
         },
     },
+    # Drive Time Tools (Feature 017)
+    {
+        "name": "get_drive_times",
+        "description": "Get all stored drive times for common locations. Returns a list of locations and their drive times from home in minutes. Call this during daily plan generation to insert travel buffers.",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+        },
+    },
+    {
+        "name": "save_drive_time",
+        "description": "Save or update a drive time for a location. Use when the user says something like 'the gym is 5 minutes away' or 'school is 10 minutes from home'.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "Location name (e.g., 'gym', 'school', 'grandma'). Articles like 'the' are stripped automatically.",
+                },
+                "minutes": {
+                    "type": "integer",
+                    "description": "One-way drive time from home in minutes (1-120).",
+                },
+            },
+            "required": ["location", "minutes"],
+        },
+    },
+    {
+        "name": "delete_drive_time",
+        "description": "Remove a stored drive time for a location.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "location": {
+                    "type": "string",
+                    "description": "Location name to remove (e.g., 'gym'). Case-insensitive.",
+                },
+            },
+            "required": ["location"],
+        },
+    },
 ]
 
 # Color mapping for calendar blocks
@@ -1490,6 +1568,10 @@ TOOL_FUNCTIONS = {
         else routines.get_routine(kw.get("_phone", ""), kw["name"])
     ),
     "delete_routine": lambda **kw: routines.delete_routine(kw.get("_phone", ""), kw["name"]),
+    # Drive Time Tools (Feature 017)
+    "get_drive_times": lambda **kw: drive_times.get_drive_times(),
+    "save_drive_time": lambda **kw: drive_times.save_drive_time(kw["location"], kw["minutes"]),
+    "delete_drive_time": lambda **kw: drive_times.delete_drive_time(kw["location"]),
 }
 
 

--- a/src/context.py
+++ b/src/context.py
@@ -223,6 +223,14 @@ def get_daily_context(phone: str) -> str:
     pref_line = _format_preferences(phone)
     lines.append(f"\u2699\ufe0f {pref_line}")
 
+    # --- Drive times ---
+    try:
+        from src import drive_times as _dt
+        dt_text = _dt.get_drive_times()
+        lines.append(f"\U0001f697 {dt_text}")
+    except Exception as e:
+        logger.warning("Could not load drive times: %s", e)
+
     # --- Calendar status ---
     cal_status = "available" if calendar_available else "unavailable"
     lines.append(f"\U0001f4c5 Calendar: {cal_status}")

--- a/src/drive_times.py
+++ b/src/drive_times.py
@@ -1,0 +1,144 @@
+"""Persistent drive time storage for the family assistant.
+
+Stores location-to-drive-time mappings in a JSON file so the bot remembers
+how long it takes to drive to common destinations (gym, school, church, etc.)
+across conversations and container restarts.
+
+Persistence: data/drive_times.json (local) or /app/data/drive_times.json (Docker).
+Pattern: in-memory dict + atomic JSON file writes (same as routines.py, preferences.py).
+"""
+
+import json
+import logging
+from datetime import datetime
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MAX_DRIVE_TIMES = 20
+MIN_MINUTES = 1
+MAX_MINUTES = 120
+
+# ---------------------------------------------------------------------------
+# File paths (Docker vs local dev)
+# ---------------------------------------------------------------------------
+
+_DATA_DIR = Path("/app/data") if Path("/app/data").exists() else Path("data")
+_DRIVE_TIMES_FILE = _DATA_DIR / "drive_times.json"
+
+# ---------------------------------------------------------------------------
+# In-memory cache
+# ---------------------------------------------------------------------------
+
+_drive_times: dict[str, dict] = {}
+
+
+# ---------------------------------------------------------------------------
+# File I/O (atomic writes)
+# ---------------------------------------------------------------------------
+
+def _load_drive_times() -> None:
+    """Load drive times from JSON file into memory."""
+    global _drive_times
+    try:
+        if _DRIVE_TIMES_FILE.exists():
+            _drive_times = json.loads(_DRIVE_TIMES_FILE.read_text())
+            logger.info("Loaded %d drive time(s)", len(_drive_times))
+        else:
+            _drive_times = {}
+    except Exception as e:
+        logger.warning("Failed to load drive times: %s — starting empty", e)
+        _drive_times = {}
+
+
+def _save_drive_times() -> None:
+    """Save drive times atomically (write to .tmp then rename)."""
+    try:
+        _DATA_DIR.mkdir(parents=True, exist_ok=True)
+        tmp = _DRIVE_TIMES_FILE.with_suffix(".tmp")
+        tmp.write_text(json.dumps(_drive_times, indent=2))
+        tmp.replace(_DRIVE_TIMES_FILE)
+    except Exception as e:
+        logger.error("Failed to save drive times: %s", e)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def _normalize_location(location: str) -> str:
+    """Normalize location name: lowercase, strip articles."""
+    loc = location.strip().lower()
+    for prefix in ("the ", "a ", "an "):
+        if loc.startswith(prefix):
+            loc = loc[len(prefix):]
+    return loc
+
+
+def get_drive_times() -> str:
+    """Return all stored drive times as a formatted string.
+
+    Returns a human-readable list for Claude to use during plan generation,
+    or a message indicating no drive times are stored.
+    """
+    if not _drive_times:
+        return "No drive times stored. Erin can add them by saying something like 'the gym is 5 minutes away.'"
+
+    lines = ["Stored drive times (from home):"]
+    for location, info in sorted(_drive_times.items()):
+        lines.append(f"• {location}: {info['minutes']} min")
+    return "\n".join(lines)
+
+
+def save_drive_time(location: str, minutes: int) -> str:
+    """Add or update a drive time for a location.
+
+    Location names are normalized to lowercase with articles stripped.
+    Returns a confirmation string.
+    """
+    loc = _normalize_location(location)
+    if not loc:
+        return "Please provide a location name."
+
+    if not (MIN_MINUTES <= minutes <= MAX_MINUTES):
+        return f"Drive time must be between {MIN_MINUTES} and {MAX_MINUTES} minutes."
+
+    is_update = loc in _drive_times
+    _drive_times[loc] = {
+        "minutes": minutes,
+        "updated": datetime.now().isoformat(),
+    }
+
+    # Cap at MAX_DRIVE_TIMES — shouldn't happen with <10 locations but safe
+    if len(_drive_times) > MAX_DRIVE_TIMES:
+        return f"You've reached the maximum of {MAX_DRIVE_TIMES} stored locations. Please delete some first."
+
+    _save_drive_times()
+    action = "Updated" if is_update else "Saved"
+    logger.info("%s drive time: %s = %d min", action, loc, minutes)
+    return f"{action} drive time: {loc} is {minutes} minutes from home."
+
+
+def delete_drive_time(location: str) -> str:
+    """Remove a stored drive time by location name.
+
+    Returns a confirmation string or a not-found message.
+    """
+    loc = _normalize_location(location)
+    if loc in _drive_times:
+        del _drive_times[loc]
+        _save_drive_times()
+        logger.info("Deleted drive time for %s", loc)
+        return f"Removed drive time for {loc}."
+    return f"No drive time stored for '{loc}'."
+
+
+# ---------------------------------------------------------------------------
+# Auto-load on module import
+# ---------------------------------------------------------------------------
+
+_load_drive_times()


### PR DESCRIPTION
## Summary
- **US1**: Calendar-aware plan generation — existing events treated as fixed, immovable blocks (rules 9a-9d)
- **US2**: Confirm-before-write — plans presented as drafts, calendar writes only after explicit approval (rules 14, 14a-14e)
- **US3**: Drive time buffers — persistent location→minutes storage with auto-inserted travel buffers (rules 15c-15f, new `src/drive_times.py`)

## Changes
- `src/assistant.py` — system prompt rules + 3 new tools (get_drive_times, save_drive_time, delete_drive_time)
- `src/drive_times.py` — new module, atomic JSON pattern (same as routines.py)
- `src/context.py` — include drive times in daily context output
- `CLAUDE.md` — agent context update

## Test plan
- [ ] "plan my day" on weekday → school drop-off/pickup appear as fixed blocks
- [ ] Plan presented as draft → modify → approve → calendar written once
- [ ] Store drive time via conversation → plan includes travel buffer
- [ ] Morning briefing does not auto-write to calendar

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)