### PR TITLE
fix: Amazon $0 orders, Calendar retry, shared event ownership

### DIFF
--- a/src/assistant.py
+++ b/src/assistant.py
@@ -291,6 +291,13 @@ original message as the event description for context. The event goes on the \
 shared family calendar so both partners can see it. Use the date and time \
 shown at the top of this prompt if not specified. Default to a 15-minute popup reminder.
 
+**Shared calendar event ownership:**
+43. Events on the shared family calendar may not indicate who attends. \
+Use context: "BSF" = Erin (Bible Study Fellowship), "Gymnastics" = Vienna, \
+"Church" = Family, "Nature class" = Vienna. When unsure who an event is for, \
+say so rather than guessing wrong. Events created by the bot follow the \
+"Person: event" convention (Rule 37), but older events may not.
+
 **Feature discovery & help:**
 38. When someone says "help", "what can you do?", "what are your features?", \
 "show me what you can do", or asks about capabilities, call get_help and return \

--- a/src/tools/amazon_sync.py
+++ b/src/tools/amazon_sync.py
@@ -407,7 +407,13 @@ def _parse_order_email(html_body: str, email_date: str = "") -> list[dict]:
             if grand_total is not None:
                 try:
                     grand_total = float(grand_total)
-                    if grand_total <= 0 or grand_total > 5000:
+                    if grand_total == 0:
+                        logger.info(
+                            "Skipping $0 order %s (Subscribe & Save or free promo)",
+                            order.get("order_number", "?"),
+                        )
+                        order["grand_total"] = None
+                    elif grand_total < 0 or grand_total > 5000:
                         logger.warning("Rejected unreasonable total: %s", grand_total)
                         order["grand_total"] = None
                     else:

--- a/src/tools/calendar.py
+++ b/src/tools/calendar.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 from zoneinfo import ZoneInfo
@@ -73,11 +74,21 @@ def _get_service():
     if not creds and os.path.exists(TOKEN_PATH):
         creds = Credentials.from_authorized_user_file(TOKEN_PATH, SCOPES)
 
-    # Refresh if expired
+    # Refresh if expired (with retry for transient network failures)
     if creds and not creds.valid:
         if creds.expired and creds.refresh_token:
-            creds.refresh(Request())
-            logger.info("Google credentials refreshed successfully")
+            for attempt in range(3):
+                try:
+                    creds.refresh(Request())
+                    logger.info("Google credentials refreshed successfully")
+                    break
+                except Exception as e:
+                    if attempt < 2:
+                        logger.warning("Token refresh attempt %d failed: %s", attempt + 1, e)
+                        time.sleep(2**attempt)
+                    else:
+                        logger.error("Token refresh failed after 3 attempts: %s", e)
+                        raise
         else:
             creds = None  # Can't refresh, need new auth
 


### PR DESCRIPTION
## Summary
- **#9**: Allow $0 Amazon orders (Subscribe & Save, free promos) instead of rejecting as unreasonable — skip YNAB matching gracefully
- **#8**: Add retry with exponential backoff (3 attempts) to Google OAuth token refresh for transient network failures
- **#14**: Add Rule 43 mapping shared calendar events to family members (BSF=Erin, Gymnastics=Vienna, Church=Family, etc.)

## Test plan
- [ ] CI lint/test/security passes
- [ ] Verify $0 Amazon orders are logged and skipped, not rejected
- [ ] Verify calendar token refresh retries on transient failure
- [ ] Verify daily plan correctly attributes shared calendar events

Closes #9, closes #8, closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)