### PR TITLE
feat: forward-to-calendar — auto-detect appointments

### DIFF
--- a/specs/025-forward-to-calendar/checklists/requirements.md
+++ b/specs/025-forward-to-calendar/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Forward-to-Calendar
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.tasks`.
+- The key insight from issue #28: this feature is primarily a prompt/instruction change — Claude already has `create_quick_event` and image processing. The main work is teaching the bot to proactively detect appointment patterns in forwarded messages.
+- US3 (drive time buffer) depends on existing `data/drive_times.json` coverage — may be limited initially.

--- a/specs/025-forward-to-calendar/spec.md
+++ b/specs/025-forward-to-calendar/spec.md
@@ -1,0 +1,111 @@
+# Feature Specification: Forward-to-Calendar
+
+**Feature Branch**: `025-forward-to-calendar`
+**Created**: 2026-03-09
+**Status**: Draft
+**Input**: GitHub issue #28 — Forward-to-calendar: auto-create events from forwarded messages
+
+## User Scenarios & Testing
+
+### User Story 1 - Extract Event from Forwarded Text (Priority: P1)
+
+Erin receives a text confirmation (doctor appointment, service visit, school event) and forwards it to the family WhatsApp group. The bot detects appointment-like content, extracts the date/time/location/details, and offers to create a calendar event. Erin confirms, and the event appears on the appropriate calendar with a reminder.
+
+**Why this priority**: This is the core feature — Erin already manually converts forwarded confirmations into calendar entries. Eliminating that friction is the primary value.
+
+**Independent Test**: Forward a message like "Your appointment with Dr. Smith is confirmed for March 10 at 2:00 PM at 1234 S Virginia St" to the bot. Bot responds with extracted details and asks for confirmation. After confirming, event appears in Google Calendar with reminder.
+
+**Acceptance Scenarios**:
+
+1. **Given** a forwarded text containing an appointment confirmation with date, time, and location, **When** Erin sends it to the bot, **Then** the bot extracts the event details and presents them for confirmation before creating a calendar event.
+2. **Given** a forwarded text with an appointment confirmation, **When** Erin confirms the extracted details, **Then** the event is created on the family calendar with a 15-minute reminder and the bot confirms creation with the event summary.
+3. **Given** a forwarded text with a location included, **When** the bot creates the event, **Then** the location is included in the calendar event details.
+
+---
+
+### User Story 2 - Extract Event from Screenshot/Image (Priority: P2)
+
+Erin screenshots a confirmation screen from an app or email and sends the image to the bot. The bot reads the image, extracts appointment details, and offers to create a calendar event — same flow as text forwarding.
+
+**Why this priority**: Some confirmations arrive as app notifications or emails that are easier to screenshot than copy-paste. The bot already has image/OCR capability, so this extends US1 to visual input.
+
+**Independent Test**: Send a screenshot of an appointment confirmation (e.g., a doctor's office portal showing "March 15 at 3:30 PM"). Bot extracts details from the image and offers to create the event.
+
+**Acceptance Scenarios**:
+
+1. **Given** a screenshot containing appointment details (date, time, description), **When** Erin sends the image to the bot, **Then** the bot extracts the event details from the image and presents them for confirmation.
+2. **Given** a low-quality or partially obscured screenshot, **When** the bot cannot confidently extract all details, **Then** the bot asks Erin to clarify the missing information rather than guessing.
+
+---
+
+### User Story 3 - Drive Time Buffer (Priority: P3)
+
+When a forwarded message includes a location, the bot checks if drive time data is available for that destination and offers to add a travel buffer before the appointment. This ensures Erin leaves on time.
+
+**Why this priority**: Nice-to-have enhancement. The system already has drive time data — this connects it to the forwarding flow for extra convenience.
+
+**Independent Test**: Forward a message with a known location (e.g., a doctor's office address). Bot detects the location, looks up drive time, and offers to add a pre-appointment travel block.
+
+**Acceptance Scenarios**:
+
+1. **Given** a forwarded message with a recognized location and available drive time data, **When** the bot creates the event, **Then** it offers to add a travel buffer event before the appointment.
+2. **Given** a forwarded message with a location but no drive time data available, **When** the bot creates the event, **Then** it includes the location in the event but does not offer a travel buffer.
+
+---
+
+### Edge Cases
+
+- **Multiple dates in one message**: Forwarded message mentions several dates (e.g., "Your next appointments are March 10 and March 24"). Bot should ask which date(s) to create events for, or offer to create events for all.
+- **Cancellation language**: Message says "Your appointment on March 10 has been cancelled." Bot should recognize this as a cancellation, not create a new event, and optionally offer to remove an existing matching event.
+- **Ambiguous times**: Message says "tomorrow afternoon" or "next Thursday morning." Bot should ask for clarification on the specific time.
+- **Time ranges**: Service windows like "between 1-3 PM on Thursday." Bot should create an event spanning the full range.
+- **Recurring appointment mention**: "See you in 6 months for your next checkup." Bot should not create an event 6 months out unless explicitly asked.
+- **Non-appointment forwarded messages**: Erin forwards a funny message or news article. Bot should not falsely detect an appointment — only act when appointment-like patterns are clearly present.
+- **Past dates**: Forwarded message references a date that has already passed. Bot should flag this and ask if Erin still wants to create the event.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST detect appointment-like content in forwarded text messages by identifying patterns such as confirmed appointments, scheduled visits, reservations, and similar language.
+- **FR-002**: System MUST extract structured event details from detected appointments: event title/description, date, time (start and optionally end), and location (if present).
+- **FR-003**: System MUST present extracted details to the user for confirmation before creating any calendar event — never auto-create without user approval.
+- **FR-004**: System MUST create the calendar event on the family calendar by default, with the option for the user to specify a different calendar (jason, erin) during confirmation.
+- **FR-005**: System MUST handle image/screenshot input by reading the image content and extracting appointment details, using the same confirmation flow as text messages.
+- **FR-006**: System MUST recognize cancellation language and offer to remove a matching existing event rather than creating a new one.
+- **FR-007**: System MUST ask for clarification when dates or times are ambiguous rather than guessing incorrectly.
+- **FR-008**: System MUST ignore forwarded messages that do not contain appointment-relevant content — no false positives on casual conversation, jokes, or news.
+- **FR-009**: System MUST include any mentioned location in the calendar event's location field.
+- **FR-010**: When drive time data is available for the event location, system SHOULD offer to add a travel buffer event before the appointment.
+
+### Key Entities
+
+- **Forwarded Message**: The raw text or image sent by the user, containing potential appointment information. Key attributes: message content, media type (text or image), sender context.
+- **Extracted Event**: The structured appointment details parsed from the message. Key attributes: title, date, start time, end time (if applicable), location, description, source message.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 90% of forwarded appointment confirmations with explicit date and time are correctly extracted on the first attempt without user correction.
+- **SC-002**: Users can go from forwarding a message to having a calendar event created in under 30 seconds (one confirmation step).
+- **SC-003**: Zero calendar events are created without explicit user confirmation.
+- **SC-004**: False positive rate (non-appointment messages incorrectly flagged as appointments) is below 5%.
+- **SC-005**: Image-based appointment extraction succeeds for at least 80% of clearly legible screenshots.
+
+## Assumptions
+
+- Forwarded messages arrive through the existing WhatsApp message pipeline — no new intake channel is needed.
+- The bot's existing natural language understanding is sufficient to detect appointment patterns — no custom NLP model is required.
+- The bot's existing image/vision capability can read standard appointment confirmation screenshots.
+- Drive time data in `data/drive_times.json` contains entries for common destinations (doctor, school, etc.) but coverage is not guaranteed for all locations.
+- The user will always confirm before an event is created — the bot never auto-creates events from forwarded content.
+- Most forwarded appointments are for the near future (within 90 days). Events more than 90 days out are still created but may warrant a double-check with the user.
+
+## Out of Scope
+
+- Automatic calendar event creation without user confirmation.
+- Parsing complex multi-event itineraries (e.g., full travel itineraries with flights, hotels, activities).
+- Integrating with external services to look up appointment details (e.g., calling a doctor's office API).
+- Handling forwarded emails directly — only WhatsApp messages and images are in scope.
+- Real-time address geocoding or map integration for drive time estimation — uses existing static drive time data only.

--- a/specs/025-forward-to-calendar/tasks.md
+++ b/specs/025-forward-to-calendar/tasks.md
@@ -1,0 +1,146 @@
+# Tasks: Forward-to-Calendar
+
+**Input**: Design documents from `/specs/025-forward-to-calendar/`
+**Prerequisites**: spec.md (no plan.md needed — prompt-engineering feature extending existing tools)
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing of each story.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new dependencies needed — Claude already has calendar tools, image processing, and drive time data. No setup tasks.
+
+*(No tasks)*
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Add `location` support to the calendar event tool — needed by all user stories but missing from `create_quick_event()`.
+
+- [x] T001 Add optional `location` parameter to `create_quick_event()` in src/tools/calendar.py. When provided, add `"location": location` to the event body dict before the `events().insert()` call. When not provided, behavior is unchanged.
+- [x] T002 Update the `create_quick_event` tool schema in src/assistant.py. Add `location` property: `{"type": "string", "description": "Physical address or place name for the event. Shown in calendar event details and enables map links."}`. Do NOT add to `required`.
+- [x] T003 [P] Update the `create_quick_event` tool description in src/prompts/tools/calendar.md. Add a note that `location` can be included for events with a physical address (doctor offices, schools, restaurants, etc.). The location appears in the calendar event and enables map links on mobile.
+
+**Checkpoint**: `create_quick_event` now supports location. Foundation ready for all user stories.
+
+---
+
+## Phase 3: User Story 1 — Extract Event from Forwarded Text (Priority: P1) MVP
+
+**Goal**: When Erin forwards a text containing an appointment confirmation, the bot detects the appointment, extracts details, and offers to create a calendar event after confirmation.
+
+**Independent Test**: Forward "Your appointment with Dr. Smith is confirmed for March 10 at 2:00 PM at 1234 S Virginia St" to the bot. Bot presents extracted details, asks for confirmation, creates event on confirm.
+
+### Implementation for User Story 1
+
+- [x] T004 [US1] Add a new system prompt section `src/prompts/system/09-forward-to-calendar.md` with instructions for detecting appointment-like content in messages. Rules should cover: (1) When a message contains appointment/confirmation/reservation/scheduled language with a date and time, proactively offer to create a calendar event. (2) Extract: title/description, date, start time, end time (if present), location (if present). (3) Present extracted details to the user and ask for confirmation before creating. (4) Never auto-create without explicit user approval. (5) If date or time is ambiguous, ask for clarification. (6) Recognize cancellation language ("has been cancelled", "appointment cancelled") and offer to find and remove the matching event instead. (7) Ignore messages that are clearly not appointments (jokes, news, casual chat). (8) If multiple dates are mentioned, ask which to create events for. (9) If the date has already passed, flag it and ask if user still wants to create the event. (10) Default to family calendar; ask which calendar if unclear. Include 4-5 examples of appointment patterns: doctor confirmation, service window ("between 1-3 PM"), school event, playdate.
+- [ ] T005 [US1] Verify US1 works end-to-end: start the app locally or use deployed instance. Send a test message like "Your appointment with Dr. Smith is confirmed for March 15 at 2:00 PM at 1234 S Virginia St, Reno NV." Confirm: (1) bot detects appointment pattern without being asked, (2) bot presents extracted details (title, date, time, location), (3) bot asks for confirmation, (4) after confirming, event appears in Google Calendar with location field populated. Clean up test event after verification.
+
+**Checkpoint**: Forwarded text appointments auto-detected and converted to calendar events. MVP complete.
+
+---
+
+## Phase 4: User Story 2 — Extract Event from Screenshot/Image (Priority: P2)
+
+**Goal**: When Erin sends a screenshot of an appointment confirmation, the bot reads the image, extracts details, and offers to create a calendar event — same flow as text.
+
+**Depends on**: US1 (same system prompt rules apply; image pipeline already sends images to Claude with the system prompt)
+
+**Independent Test**: Send a screenshot of an appointment confirmation. Bot extracts details from the image and offers to create the event.
+
+### Implementation for User Story 2
+
+- [x] T006 [US2] Update src/prompts/system/09-forward-to-calendar.md to explicitly mention that these appointment detection rules also apply when the user sends a photo/screenshot. Add a note: "When the user sends an image, look for appointment details visible in the screenshot (confirmation screens, calendar entries, text message screenshots). Apply the same extraction and confirmation flow as for text messages. If the image is unclear or details are hard to read, ask the user to clarify rather than guessing."
+- [ ] T007 [US2] Verify US2 works: send a screenshot of an appointment confirmation (e.g., a photo of a text message saying "Your dentist appointment is March 20 at 10:30 AM"). Confirm: (1) bot reads the image and detects appointment content, (2) bot presents extracted details, (3) after confirmation, event is created. Clean up test event.
+
+**Checkpoint**: Both text and image appointment forwarding work.
+
+---
+
+## Phase 5: User Story 3 — Drive Time Buffer (Priority: P3)
+
+**Goal**: When a forwarded appointment includes a location with known drive time data, the bot offers to add a travel buffer event before the appointment.
+
+**Depends on**: US1 (need appointment detection working first)
+
+**Independent Test**: Forward a message with a location that exists in drive_times.json. Bot offers to add a travel buffer before the appointment.
+
+### Implementation for User Story 3
+
+- [x] T008 [US3] Update src/prompts/system/09-forward-to-calendar.md to add drive time buffer instructions. Add a rule: "After the user confirms an appointment event that includes a location, check if drive time data is available for that location using the `get_drive_times` tool. If a matching location is found, offer to create an additional 'Travel to [location]' calendar block before the appointment, starting [drive_minutes] minutes before the event. If no drive time data exists for the location, skip the offer — do not ask the user to add drive time data during this flow." Include an example: "I see Dr. Smith's office is about 15 minutes away. Want me to add a travel block from 1:30-1:45 PM before your 2:00 PM appointment?"
+- [ ] T009 [US3] Verify US3 works: ensure a test location exists in drive_times.json (e.g., "doctor" → 15 minutes). Forward a message mentioning that location. Confirm: (1) bot detects appointment, (2) after confirmation, bot offers drive time buffer, (3) if accepted, travel block event is created before the appointment.
+
+**Checkpoint**: Full forward-to-calendar flow — detect, extract, confirm, create, optional drive time buffer.
+
+---
+
+## Phase 6: Polish & Validation
+
+**Purpose**: Final checks and deployment.
+
+- [x] T010 Run `ruff check src/` and `ruff format --check src/` — fix any issues in modified files.
+- [x] T011 Run `pytest tests/` — verify all existing tests still pass.
+- [x] T012 Update the tool count in tests/test_prompts.py if the total changed (currently asserts 73). Check by counting `## ` headers in all src/prompts/tools/*.md files.
+- [ ] T013 Commit all changes, push to branch, create PR for merge to main.
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: N/A
+- **Foundational (Phase 2)**: T001-T003 — Add location support to create_quick_event. Blocks US1.
+- **US1 (Phase 3)**: T004-T005 — Depends on Phase 2. Core prompt engineering.
+- **US2 (Phase 4)**: T006-T007 — Depends on US1 (extends same prompt file).
+- **US3 (Phase 5)**: T008-T009 — Depends on US1 (extends same prompt file).
+- **Polish (Phase 6)**: T010-T013 — After all user stories.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Independent — MVP. New system prompt section + existing tools.
+- **US2 (P2)**: Depends on US1 (same prompt file, adds image-specific guidance).
+- **US3 (P3)**: Depends on US1 (same prompt file, adds drive time buffer logic).
+
+### Parallel Opportunities
+
+- T003 (tool description) can run in parallel with T001-T002 (different file)
+- T001 and T002 are sequential (same logical change across two files)
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. T001-T003 — Add location param to create_quick_event
+2. T004 — Write the forward-to-calendar system prompt section
+3. T005 — Verify end-to-end
+4. **STOP and VALIDATE**: Can detect and create events from forwarded text
+5. Deploy — Erin can immediately forward appointment confirmations
+
+### Incremental Delivery
+
+1. T001-T005 → US1 complete → Text appointment forwarding works
+2. T006-T007 → US2 complete → Screenshot appointment forwarding works
+3. T008-T009 → US3 complete → Drive time buffers offered
+4. T010-T013 → Polish → CI passes, PR created
+
+---
+
+## Notes
+
+- Total: 13 tasks
+- Files modified: src/tools/calendar.py (1 param), src/assistant.py (1 schema property), src/prompts/tools/calendar.md (1 description update), src/prompts/system/09-forward-to-calendar.md (new file), tests/test_prompts.py (count check)
+- No new Python dependencies — this is primarily a prompt engineering feature
+- Claude already understands appointment language — the system prompt just needs to instruct it to proactively detect and act on it
+- The key insight: forwarded messages arrive as regular text/images through the existing pipeline. Claude just needs instructions to recognize appointment patterns and offer to create calendar events.
+- Image handling (US2) requires no code changes — images already go through the vision pipeline with the system prompt. Adding image guidance to the prompt section is sufficient.

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -497,6 +497,13 @@ TOOLS = [
                     "description": "Target calendar. Default: family.",
                     "default": "family",
                 },
+                "location": {
+                    "type": "string",
+                    "description": (
+                        "Physical address or place name for the event. "
+                        "Shown in calendar event details and enables map links on mobile."
+                    ),
+                },
             },
             "required": ["summary", "start_time"],
         },
@@ -1420,6 +1427,7 @@ TOOL_FUNCTIONS = {
         int(kw.get("reminder_minutes", 15)),
         kw.get("recurrence"),
         kw.get("calendar_name", "family"),
+        kw.get("location", ""),
     ),
     "delete_calendar_event": lambda **kw: calendar.delete_calendar_event(
         kw["event_id"],

--- a/src/prompts/system/09-forward-to-calendar.md
+++ b/src/prompts/system/09-forward-to-calendar.md
@@ -1,0 +1,25 @@
+**Forward-to-calendar — auto-detect appointments in messages:**
+44. When a message contains appointment-like language — confirmed, scheduled, reservation, appointment, booked — along with a date and time, proactively offer to create a calendar event. This applies to both text messages and photos/screenshots of confirmations. Do NOT auto-create the event. Instead:
+    a. Extract: event title/description, date, start time, end time (if present), and location (if present).
+    b. Present the extracted details clearly and ask the user to confirm before creating the event.
+    c. Default to the family calendar. If the appointment is clearly personal to one partner (e.g., "Dr. Smith" for Erin), suggest their personal calendar but let them choose.
+    d. Use `create_quick_event` with the `location` parameter when an address or place name is included.
+
+45. Appointment detection examples — recognize these patterns:
+    - Doctor/dentist: "Your appointment with Dr. Smith is confirmed for March 10 at 2:00 PM at 1234 S Virginia St"
+    - Service window: "Your Comcast technician will arrive between 1-3 PM on Thursday" → create event spanning 1-3 PM
+    - School event: "Parent-teacher conference scheduled for March 15 at 3:30 PM"
+    - Reservation: "Reservation confirmed at Olive Garden for Saturday at 6:30 PM, party of 4"
+    - Playdate: "How about Saturday at 10 at the park?" → only offer if it reads like a confirmed plan, not a tentative suggestion
+
+46. Appointment edge cases:
+    a. **Cancellation language**: If the message says "cancelled", "canceled", or "no longer scheduled", do NOT create an event. Instead, offer to find and remove the matching existing event using `get_calendar_events` and `delete_calendar_event`.
+    b. **Ambiguous times**: If the time is vague ("tomorrow afternoon", "next Thursday morning"), ask for the specific time before creating the event.
+    c. **Multiple dates**: If the message mentions several dates ("Your next appointments are March 10 and March 24"), ask which date(s) to create events for or offer to create all of them.
+    d. **Past dates**: If the mentioned date has already passed, flag it: "That date has already passed — did you still want me to add it to the calendar?"
+    e. **Recurring mention**: If the message says "see you in 6 months" or "next annual checkup", do NOT create an event 6 months out unless the user explicitly asks.
+    f. **Non-appointments**: Do NOT flag casual conversation, jokes, news articles, or messages that happen to mention a date without appointment intent. Only act when the language clearly indicates a scheduled event.
+
+47. When the user sends a photo or screenshot, look for appointment details visible in the image (confirmation screens, calendar entries, text message screenshots, email confirmations). Apply the same extraction and confirmation flow as for text messages. If the image is unclear or details are hard to read, ask the user to clarify the missing information rather than guessing.
+
+48. After the user confirms an appointment that includes a location, check if drive time data is available using `get_drive_times`. If a matching location is found, offer to add a "Travel to [location]" calendar block before the appointment, starting the appropriate number of minutes before the event. Example: "I see Dr. Smith's office is about 15 minutes away. Want me to add a travel block from 1:30-1:45 PM before your 2:00 PM appointment?" If no drive time data exists for the location, skip the offer silently.

--- a/src/prompts/tools/calendar.md
+++ b/src/prompts/tools/calendar.md
@@ -24,6 +24,8 @@ For recurring events, generate an RRULE from the user's natural language and pas
 
 Omit `recurrence` entirely for one-time events. Use `calendar_name` to target a specific calendar (family, jason, erin). After creating a recurring event, confirm the pattern and list the next 3-4 upcoming dates so the user can verify.
 
+Use `location` for events with a physical address (doctor offices, schools, restaurants, service appointments). The location appears in the calendar event details and enables map links on mobile devices.
+
 ## delete_calendar_event
 
 Delete a single occurrence or all future occurrences of a calendar event. Use `cancel_mode: "single"` when the user says "no swim this Monday" or "skip cleaners next week" — this cancels just one date. Use `cancel_mode: "all_following"` when the user says "cancel the cleaners" or "stop the recurring swim class" — this deletes the entire series. To find the event_id, first use `get_calendar_events` or `get_events_for_date` to locate the event. When the user asks to cancel a recurring event, ask whether they mean just this one or all future occurrences.

--- a/src/tools/calendar.py
+++ b/src/tools/calendar.py
@@ -333,6 +333,7 @@ def create_quick_event(
     reminder_minutes: int = 15,
     recurrence: list[str] | None = None,
     calendar_name: str = "family",
+    location: str = "",
 ) -> str:
     """Create a quick reminder/event on a Google Calendar.
 
@@ -380,6 +381,8 @@ def create_quick_event(
     }
     if description:
         event_body["description"] = description
+    if location:
+        event_body["location"] = location
     if recurrence:
         event_body["recurrence"] = recurrence
 


### PR DESCRIPTION
## Summary
- New system prompt section (`09-forward-to-calendar.md`) teaches the bot to proactively detect appointment confirmations in messages and offer to create calendar events
- Added `location` parameter to `create_quick_event` — addresses appear in calendar events with map links
- Covers text messages, screenshot/image OCR, cancellation detection, drive time buffer offers
- Edge cases: ambiguous times, past dates, multiple dates, non-appointment messages

## What changed
- `src/prompts/system/09-forward-to-calendar.md` — new file (rules 44-48)
- `src/tools/calendar.py` — `location` param on `create_quick_event()`
- `src/assistant.py` — `location` in tool schema + lambda
- `src/prompts/tools/calendar.md` — location usage note

## Test plan
- [ ] `ruff check src/` and `ruff format --check src/` pass
- [ ] `pytest tests/` passes (7/7)
- [ ] Send "Your appointment with Dr. Smith is confirmed for March 15 at 2:00 PM at 1234 S Virginia St" — bot offers to create event
- [ ] Confirm → event created with location field populated
- [ ] Send screenshot of appointment confirmation → bot extracts and offers event
- [ ] Send "Your appointment has been cancelled" → bot offers to find and remove event

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)