### PR TITLE
fix: include config/ directory in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY src/ src/
+COPY config/ config/
 COPY data/schedules.json /app/defaults/schedules.json
 
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- Dockerfile was missing `COPY config/ config/` — family.yaml wasn't in the container
- App worked via hardcoded fallback defaults, but wasn't actually using the YAML config file

## Test plan
- [x] Dockerfile change is one line — adds `COPY config/ config/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)