### PR TITLE
fix: pass family config placeholders to conflict_detection template

### DIFF
--- a/src/tools/proactive.py
+++ b/src/tools/proactive.py
@@ -369,6 +369,11 @@ def detect_conflicts(days_ahead: int = 1) -> list[dict]:
         cal_events=cal_events_raw,
         outlook_events=outlook_events_raw,
         templates=templates,
+        partner1_name=FAMILY_CONFIG.get("partner1_name", "Partner1"),
+        partner1_name_lower=FAMILY_CONFIG.get("partner1_name_lower", "partner1"),
+        partner2_name=FAMILY_CONFIG.get("partner2_name", "Partner2"),
+        partner2_name_lower=FAMILY_CONFIG.get("partner2_name_lower", "partner2"),
+        caregiver_names=FAMILY_CONFIG.get("caregiver_names", ""),
     )
 
     response = client.messages.create(


### PR DESCRIPTION
## Summary
- The `conflict_detection.md` prompt template uses `{partner1_name}`, `{partner2_name_lower}`, `{caregiver_names}` placeholders but `detect_conflicts()` wasn't passing them, causing `KeyError: 'partner1_name'` at runtime
- Pre-existing bug from Feature 028 template externalization, discovered during live API testing of PR #49

## Test plan
- [x] `ruff check src/` passes
- [x] `pytest tests/` — 18/18 pass
- [ ] Live test: POST `/api/v1/calendar/conflict-check` no longer raises KeyError

🤖 Generated with [Claude Code](https://claude.com/claude-code)