### PR TITLE
fix: pass children placeholders to meal_plan_generation template

### DIFF
--- a/src/tools/proactive.py
+++ b/src/tools/proactive.py
@@ -193,6 +193,8 @@ def generate_meal_plan() -> dict:
         recipe_count=len(all_recipes),
         recipes_summary=recipes_summary,
         recent_plans=recent_plans[:2] if recent_plans else "None",
+        children_summary=FAMILY_CONFIG.get("children_summary", ""),
+        children_activities_summary=FAMILY_CONFIG.get("children_activities_summary", ""),
     )
 
     response = client.messages.create(


### PR DESCRIPTION
## Summary
- `meal_plan_generation.md` template uses `{children_summary}` and `{children_activities_summary}` but `generate_meal_plan()` wasn't passing them, causing `KeyError` at runtime
- Same class of bug as PR #50 (conflict_detection template)

## Test plan
- [x] `ruff check src/` passes
- [x] `pytest tests/` — 18/18 pass
- [ ] Live test: POST `/api/v1/meals/plan-week` no longer raises KeyError

🤖 Generated with [Claude Code](https://claude.com/claude-code)