### PR TITLE
feat: quick start onboarding — integration registry + dynamic filtering

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,21 +51,51 @@ Family-specific values are externalized in `config/family.yaml` (YAML format, hu
 
 **Adding a new family-specific value:** Add the field to `config/family.yaml`, add a derived key in `_build_placeholder_dict()` in `src/family_config.py`, then use `{new_key}` in prompt files.
 
+## Integration Registry
+
+The integration registry (`src/integrations.py`) is the single source of truth for which integrations exist, what env vars they need, and which tools they provide. It drives tool filtering, prompt section filtering, health checks, and the validation script.
+
+**Key concepts:**
+- `INTEGRATION_REGISTRY` — dict mapping integration name → `Integration` dataclass (display_name, required, env_vars, tools, prompt_tag, always_enabled)
+- 9 integrations: `core`, `whatsapp`, `ai_api`, `notion`, `google_calendar`, `outlook`, `ynab`, `anylist`, `recipes`
+- `core` is a pseudo-integration (always_enabled=True, no env vars) — represents base tools available in every deployment
+- `get_enabled_integrations()` — checks `os.environ` directly (not config.py defaults) and returns set of enabled integration names
+- `ENABLED_INTEGRATIONS` in `src/config.py` — computed once at startup from registry
+
+**Adding a new integration:** Add an `Integration` entry to `INTEGRATION_REGISTRY` in `src/integrations.py` with its env vars and tools. Add a frontmatter tag to relevant prompt files. The tool filtering, health endpoint, and validation script automatically pick it up.
+
+**Adding a tool to an existing integration:** Add the tool name to the integration's `tools` tuple in `INTEGRATION_REGISTRY`. It will automatically be included/excluded based on whether that integration is enabled.
+
 ## Prompt Architecture
 
 All LLM prompts live in `src/prompts/` as external Markdown files, loaded at startup via `@lru_cache`, then rendered with family config placeholders.
 
 **Directory structure:**
-- `src/prompts/system/` — System prompt sections (9 numbered `.md` files, concatenated in sort order)
-- `src/prompts/tools/` — Tool descriptions (12 module-grouped `.md` files, parsed by `## tool_name` headers)
+- `src/prompts/system/` — System prompt sections (10 numbered `.md` files, concatenated in sort order, filtered by YAML frontmatter)
+- `src/prompts/tools/` — Tool descriptions (12 module-grouped `.md` files, parsed by `## tool_name` headers, filtered by enabled tools)
 - `src/prompts/templates/` — Classification/generation prompt templates (10 `.md` files with `{placeholder}` syntax)
 - `src/prompts/__init__.py` — Loader module: `load_system_prompt()`, `render_system_prompt()`, `load_tool_descriptions()`, `render_tool_descriptions()`, `render_template(name, **kwargs)`
 
+**Prompt frontmatter convention:** System prompt files use YAML frontmatter to declare which integrations they require:
+```yaml
+---
+requires: [core]           # ALL listed integrations must be enabled
+---
+```
+```yaml
+---
+requires_any: [notion, google_calendar]  # ANY listed integration suffices
+---
+```
+Sections without frontmatter are always included. The `_parse_frontmatter()` and `_should_include_section()` helpers in `src/prompts/__init__.py` handle filtering. Tool descriptions are filtered by tool name (matching `TOOLS` list from `src/assistant.py`).
+
 **Adding/editing prompts:**
-- System prompt: Add/edit numbered files in `system/` (e.g., `10-new-section.md`). Order matters.
+- System prompt: Add/edit numbered files in `system/` (e.g., `10-new-section.md`). Order matters. Add frontmatter if the section is integration-specific.
 - Tool descriptions: Add `## tool_name` section in the appropriate module file in `tools/`.
 - Templates: Create `name.md` in `templates/`, use `{placeholder}` for dynamic values. Escape literal braces as `{{` / `}}`.
 - Use `{partner1_name}`, `{partner2_name}`, `{bot_name}`, `{grocery_store}`, etc. for family-specific values — never hardcode names.
+
+**Pre-deployment validation:** Run `python scripts/validate_setup.py` to check family.yaml + .env configuration, integration completeness, and deployment readiness before deploying.
 
 ## Key Constraints
 
@@ -77,6 +107,8 @@ All LLM prompts live in `src/prompts/` as external Markdown files, loaded at sta
 ## Active Technologies
 - Python 3.12 (existing codebase) + FastAPI, anthropic SDK, PyYAML (new — for family config loading), existing deps unchanged (028-template-repo-readiness)
 - YAML config file at `config/family.yaml` (human-edited, committed per instance) + existing JSON data files (028-template-repo-readiness)
+- Python 3.12 + FastAPI, anthropic SDK, PyYAML (existing) (030-quick-start-onboarding)
+- JSON files in `data/` (unchanged) (030-quick-start-onboarding)
 
 **Core stack**: Python 3.12 + FastAPI, anthropic SDK (Claude Haiku 4.5 for chat, Claude vision for OCR), uvicorn, httpx, Pydantic
 
@@ -210,4 +242,5 @@ Features 001-028 are implemented and deployed. Spec artifacts for each live unde
 - 028: Template repo readiness (family config externalization, enhanced health check, onboarding/pricing docs)
 
 ## Recent Changes
+- 030-quick-start-onboarding: Added `src/integrations.py` integration registry (9 integrations, 77 tools mapped). Dynamic tool/prompt filtering based on configured integrations — minimal deployments (WhatsApp + AI only) exclude unconfigured features. YAML frontmatter on system prompt files (`requires`/`requires_any` tags). Pre-deployment validation script (`scripts/validate_setup.py`). Health endpoint uses registry for integration detection. Quick Start section in ONBOARDING.md.
 - 028-template-repo-readiness: Externalized all hardcoded family references into `config/family.yaml`. Added `src/family_config.py` YAML config loader, `render_system_prompt()`/`render_tool_descriptions()` with placeholder injection, enhanced `/health` endpoint with per-integration status, operator docs (WHATSAPP_SETUP.md, ONBOARDING.md, PRICING.md, SERVICE_AGREEMENT.md)

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -4,7 +4,50 @@ Welcome! This guide walks you through setting up your own MomBot instance — a 
 
 **You'll need**: A computer with Claude Code installed. Claude Code will guide you through each step interactively.
 
-**Time**: About 1-2 hours for the full setup.
+---
+
+## Quick Start (~30 minutes)
+
+Want to get up and running fast? You only need **WhatsApp + Claude AI** for a working assistant. All other integrations (calendar, budget, meal planning, grocery lists) are optional add-ons you can enable later.
+
+### What you get with minimal setup
+
+- AI-powered family chat assistant in WhatsApp
+- Natural language conversations with Claude
+- Preference tracking and daily context
+- Drive time lookups and routine management
+
+### Minimal setup steps
+
+1. **Clone the repo** and configure `config/family.yaml` with your family info
+2. **Set up Railway** (Step 2 below) with only the required env vars
+3. **Set up WhatsApp Business** (Step 3 below)
+4. **Deploy** (Step 4 below)
+
+### Validate your setup
+
+Before deploying, run the validation script to catch configuration errors:
+
+```bash
+python scripts/validate_setup.py --env-file .env --config-file config/family.yaml
+```
+
+This checks:
+- Family config completeness (names, timezone, partners)
+- Required environment variables (API key format, WhatsApp credentials)
+- Integration completeness (flags partially-configured integrations)
+
+A minimal deployment needs only `ANTHROPIC_API_KEY` and `WHATSAPP_*` variables. The bot automatically adapts — tools and prompt sections for unconfigured integrations are excluded, so the bot never references features that aren't set up.
+
+### Adding integrations later
+
+Once your minimal bot is working, add integrations one at a time (Steps 5-8). Re-run the validation script after each to confirm. The bot picks up new integrations on restart — no code changes needed.
+
+---
+
+## Full Setup (~1-2 hours)
+
+Follow all steps below for the complete experience with calendar, Notion, budget, and grocery list integrations.
 
 ---
 

--- a/scripts/validate_setup.py
+++ b/scripts/validate_setup.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python3
+"""Pre-deployment validation script.
+
+Validates family.yaml and .env configuration, checks integration completeness,
+and reports deployment readiness.
+
+Usage:
+    python scripts/validate_setup.py [--env-file .env] [--config-file config/family.yaml]
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+# Add project root to path so we can import src modules
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from src.integrations import INTEGRATION_REGISTRY, get_tools_for_integrations
+
+
+def _mask_key(value: str) -> str:
+    """Mask a secret value for display (show prefix + last 3 chars)."""
+    if len(value) <= 8:
+        return value[:2] + "***"
+    return value[:6] + "***..." + value[-3:]
+
+
+def validate_family_config(config_path: str) -> tuple[list[str], list[str], dict]:
+    """Validate family.yaml structure and required fields.
+
+    Returns (errors, warnings, parsed_config).
+    """
+    errors = []
+    warnings = []
+    config = {}
+    path = Path(config_path)
+
+    print(f"\nFamily Config: {config_path}")
+
+    if not path.exists():
+        errors.append(f"File not found: {config_path}")
+        print(f"  \u2717 ERROR: File not found: {config_path}")
+        return errors, warnings, config
+
+    try:
+        import yaml
+
+        config = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as e:
+        errors.append(f"Failed to parse YAML: {e}")
+        print(f"  \u2717 ERROR: Failed to parse YAML: {e}")
+        return errors, warnings, config
+
+    print("  \u2713 File exists and parses correctly")
+
+    # Required fields
+    family_name = config.get("family", {}).get("name", "") or config.get("family_name", "")
+    if family_name:
+        print(f"  \u2713 Family name: {family_name}")
+    else:
+        errors.append("Missing required field: family name")
+        print("  \u2717 ERROR: Missing required field 'family.name'")
+
+    bot = config.get("bot", {})
+    bot_name = bot.get("name", "")
+    if bot_name:
+        print(f"  \u2713 Bot name: {bot_name}")
+    else:
+        errors.append("Missing required field: bot name")
+        print("  \u2717 ERROR: Missing required field 'bot.name'")
+
+    # Timezone
+    timezone = config.get("timezone", "") or config.get("family", {}).get("timezone", "")
+    if timezone:
+        try:
+            ZoneInfo(timezone)
+            print(f"  \u2713 Timezone: {timezone} (valid)")
+        except (ZoneInfoNotFoundError, KeyError):
+            errors.append(f"Invalid timezone: {timezone}")
+            print(f"  \u2717 ERROR: Invalid timezone: {timezone}")
+    else:
+        warnings.append("No timezone set — will default to America/Los_Angeles")
+        print("  \u26a0 WARNING: No timezone set (defaults to America/Los_Angeles)")
+
+    # Partners
+    partners = config.get("family", {}).get("partners", [])
+    if not partners:
+        # Check legacy format
+        p1 = config.get("partner1_name", "")
+        p2 = config.get("partner2_name", "")
+        if p1 or p2:
+            names = [n for n in [p1, p2] if n]
+            print(f"  \u2713 Partners: {', '.join(names)}")
+        else:
+            errors.append("Missing required field: at least one partner")
+            print("  \u2717 ERROR: Missing required field 'family.partners' (at least one partner required)")
+    else:
+        names = [p.get("name", "Unknown") for p in partners]
+        print(f"  \u2713 Partners: {', '.join(names)}")
+
+    return errors, warnings, config
+
+
+def validate_env(env_path: str) -> tuple[list[str], list[str], dict[str, str]]:
+    """Validate .env file — check required vars and formats.
+
+    Returns (errors, warnings, env_vars).
+    """
+    errors = []
+    warnings = []
+    env_vars: dict[str, str] = {}
+    path = Path(env_path)
+
+    print(f"\nEnvironment: {env_path}")
+
+    if not path.exists():
+        errors.append(f"File not found: {env_path}")
+        print(f"  \u2717 ERROR: File not found: {env_path}")
+        return errors, warnings, env_vars
+
+    # Parse .env file
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+            key = key.strip()
+            value = value.strip().strip("\"'")
+            if key:
+                env_vars[key] = value
+
+    # Required vars
+    required_checks = [
+        ("ANTHROPIC_API_KEY", "sk-ant-", "Get your API key at https://console.anthropic.com/"),
+        ("WHATSAPP_PHONE_NUMBER_ID", None, "Get from Meta Business dashboard"),
+        ("WHATSAPP_ACCESS_TOKEN", None, "Get from Meta Business dashboard"),
+        ("WHATSAPP_VERIFY_TOKEN", None, "Set any random string for webhook verification"),
+        ("WHATSAPP_APP_SECRET", None, "Get from Meta App Dashboard > Settings > Basic"),
+        ("N8N_WEBHOOK_SECRET", None, "Set any random string for API auth"),
+    ]
+
+    required_passed = 0
+    required_total = len(required_checks)
+
+    for var_name, prefix, hint in required_checks:
+        value = env_vars.get(var_name, "")
+        if not value:
+            errors.append(f"{var_name} not set")
+            print(f"  \u2717 ERROR: {var_name} not set")
+            print(f"    \u2192 {hint}")
+        elif prefix and not value.startswith(prefix):
+            warnings.append(f"{var_name} format unexpected (expected {prefix}* prefix)")
+            print(f"  \u26a0 WARNING: {var_name} format unexpected (expected {prefix}* prefix)")
+            required_passed += 1
+        else:
+            display = _mask_key(value) if "KEY" in var_name or "TOKEN" in var_name or "SECRET" in var_name else "set"
+            print(f"  \u2713 {var_name}: {display}")
+            required_passed += 1
+
+    # Phone numbers
+    phone_vars = [
+        ("PARTNER1_PHONE", "JASON_PHONE"),
+        ("PARTNER2_PHONE", "ERIN_PHONE"),
+    ]
+    for primary, legacy in phone_vars:
+        value = env_vars.get(primary, "") or env_vars.get(legacy, "")
+        var_used = primary if env_vars.get(primary) else legacy
+        if not value:
+            warnings.append(f"{primary} not set (proactive messages won't be sent)")
+            print(f"  \u26a0 WARNING: {primary} not set (proactive messages won't be sent)")
+        elif not re.match(r"^\d{10,15}$", value):
+            warnings.append(f'{var_used} format invalid: "{value}" (use digits only, 10-15 chars, no + prefix)')
+            print(f'  \u2717 WARNING: {var_used} format invalid: "{value}" (digits only, 10-15 chars, no + prefix)')
+        else:
+            print(f"  \u2713 {var_used}: {value} (valid format)")
+            required_passed += 1
+            required_total += 1
+
+    return errors, warnings, env_vars
+
+
+def validate_integrations(env_vars: dict[str, str]) -> tuple[list[str], list[str], int, int]:
+    """Check integration group completeness.
+
+    Returns (errors, warnings, enabled_count, disabled_count).
+    """
+    errors = []
+    warnings = []
+    enabled_count = 0
+    disabled_count = 0
+    enabled_names = set()
+
+    print("\nIntegrations:")
+
+    for name, integration in INTEGRATION_REGISTRY.items():
+        if integration.always_enabled or integration.required:
+            continue
+
+        set_vars = [v for v in integration.env_vars if env_vars.get(v)]
+        total_vars = len(integration.env_vars)
+
+        if total_vars == 0:
+            continue
+
+        if len(set_vars) == total_vars:
+            print(f"  \u2713 {integration.display_name}: enabled ({total_vars}/{total_vars} env vars set)")
+            enabled_count += 1
+            enabled_names.add(name)
+        elif len(set_vars) == 0:
+            print(f"  \u2717 {integration.display_name}: disabled (0/{total_vars} env vars set)")
+            disabled_count += 1
+        else:
+            missing = [v for v in integration.env_vars if not env_vars.get(v)]
+            warnings.append(f"{integration.display_name} partially configured ({len(set_vars)}/{total_vars})")
+            print(
+                f"  \u26a0 {integration.display_name}: partially configured ({len(set_vars)}/{total_vars} env vars set)"
+            )
+            print(f"    Missing: {', '.join(missing)}")
+            disabled_count += 1
+
+    # Calculate tool count
+    total_tools = sum(len(i.tools) for i in INTEGRATION_REGISTRY.values())
+    enabled_names.add("core")  # Core is always enabled
+    available_tools = len(get_tools_for_integrations(enabled_names))
+
+    return errors, warnings, enabled_count, disabled_count, available_tools, total_tools
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate Family Meeting setup configuration")
+    parser.add_argument("--env-file", default=".env", help="Path to .env file (default: .env)")
+    parser.add_argument(
+        "--config-file", default="config/family.yaml", help="Path to family.yaml (default: config/family.yaml)"
+    )
+    args = parser.parse_args()
+
+    print("=== Family Meeting Setup Validation ===")
+
+    # Validate family config
+    config_errors, config_warnings, config = validate_family_config(args.config_file)
+
+    # Validate environment
+    env_errors, env_warnings, env_vars = validate_env(args.env_file)
+
+    # Validate integrations
+    int_errors, int_warnings, enabled, disabled, available_tools, total_tools = validate_integrations(env_vars)
+
+    # Summary
+    all_errors = config_errors + env_errors + int_errors
+    all_warnings = config_warnings + env_warnings + int_warnings
+
+    print(f"\nSummary: {'READY TO DEPLOY' if not all_errors else 'NOT READY'}")
+
+    if all_errors:
+        print(f"  Required: {len(all_errors)} error(s) found")
+        print("  Fix the errors above before deploying.")
+    else:
+        print("  Required: all checks passed")
+
+    print(f"  Integrations: {enabled} enabled, {disabled} disabled")
+    print(f"  Tools available: {available_tools}/{total_tools}")
+
+    if all_warnings:
+        print(f"  Warnings: {len(all_warnings)}")
+
+    sys.exit(1 if all_errors else 0)
+
+
+if __name__ == "__main__":
+    main()

--- a/specs/030-quick-start-onboarding/checklists/requirements.md
+++ b/specs/030-quick-start-onboarding/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Quick Start Onboarding
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-09
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation. Spec is ready for `/speckit.clarify` or `/speckit.plan`.
+- Assumption noted: Google Calendar OAuth still requires interactive browser flow — cannot be fully automated via YAML. This is documented in Assumptions section.
+- family.yaml credential section structure (flat vs nested, key naming) is a planning-phase decision, not a spec concern.

--- a/specs/030-quick-start-onboarding/contracts/health-endpoint.md
+++ b/specs/030-quick-start-onboarding/contracts/health-endpoint.md
@@ -1,0 +1,66 @@
+# Contract: Health Endpoint (Updated)
+
+**Type**: HTTP API
+**Endpoint**: `GET /health`
+
+## Changes from Current Behavior
+
+The only change is to the status determination logic. Unconfigured optional integrations no longer cause "degraded" status.
+
+### Current Status Logic
+```
+healthy  = all required connected AND all optional connected
+degraded = all required connected AND some optional failing
+unhealthy = any required failing
+```
+
+### New Status Logic
+```
+healthy   = all required connected AND all configured-optional connected
+degraded  = all required connected AND some configured-optional failing
+unhealthy = any required failing
+```
+
+**Key difference**: Unconfigured optional integrations (`"configured": false`) are excluded from the status calculation entirely.
+
+## Response Schema
+
+No changes to the response schema. The existing fields (`status`, `family`, `bot_name`, `uptime_seconds`, `integrations`) remain the same.
+
+## Examples
+
+### Minimal deployment (WhatsApp + AI only)
+```json
+{
+  "status": "healthy",
+  "family": "The Garcia Family",
+  "bot_name": "Home Helper",
+  "uptime_seconds": 42,
+  "integrations": {
+    "whatsapp": {"required": true, "configured": true, "connected": true, "error": null},
+    "ai_api": {"required": true, "configured": true, "connected": true, "error": null},
+    "notion": {"required": false, "configured": false, "connected": false, "error": null},
+    "google_calendar": {"required": false, "configured": false, "connected": false, "error": null},
+    "ynab": {"required": false, "configured": false, "connected": false, "error": null},
+    "anylist": {"required": false, "configured": false, "connected": false, "error": null},
+    "outlook": {"required": false, "configured": false, "connected": false, "error": null}
+  }
+}
+```
+
+Status: **healthy** (all configured integrations are connected; unconfigured ones don't count)
+
+### Full deployment with Notion failing
+```json
+{
+  "status": "degraded",
+  "integrations": {
+    "whatsapp": {"required": true, "configured": true, "connected": true, "error": null},
+    "ai_api": {"required": true, "configured": true, "connected": true, "error": null},
+    "notion": {"required": false, "configured": true, "connected": false, "error": "Connection timeout"},
+    "google_calendar": {"required": false, "configured": true, "connected": true, "error": null}
+  }
+}
+```
+
+Status: **degraded** (Notion is configured but failing)

--- a/specs/030-quick-start-onboarding/contracts/validate-setup-cli.md
+++ b/specs/030-quick-start-onboarding/contracts/validate-setup-cli.md
@@ -1,0 +1,89 @@
+# Contract: validate_setup CLI Command
+
+**Type**: CLI script
+**Location**: `scripts/validate_setup.py`
+
+## Usage
+
+```bash
+python scripts/validate_setup.py [--env-file .env] [--config-file config/family.yaml]
+```
+
+## Arguments
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--env-file` | `.env` | Path to the environment file |
+| `--config-file` | `config/family.yaml` | Path to the family config file |
+
+## Output Format
+
+Structured text output to stdout. Exit code 0 if all required checks pass, 1 if any required check fails.
+
+### Success Output
+
+```
+=== Family Meeting Setup Validation ===
+
+Family Config: config/family.yaml
+  ✓ File exists and parses correctly
+  ✓ Family name: The Garcia Family
+  ✓ Bot name: Home Helper
+  ✓ Timezone: America/Chicago (valid)
+  ✓ Partners: Maria, Carlos
+
+Environment: .env
+  ✓ ANTHROPIC_API_KEY: set (sk-ant-***...)
+  ✓ WHATSAPP_PHONE_NUMBER_ID: set
+  ✓ WHATSAPP_ACCESS_TOKEN: set
+  ✓ WHATSAPP_VERIFY_TOKEN: set
+  ✓ WHATSAPP_APP_SECRET: set
+  ✓ N8N_WEBHOOK_SECRET: set
+  ✓ PARTNER1_PHONE: 15551234567 (valid format)
+  ✓ PARTNER2_PHONE: 15552345678 (valid format)
+
+Integrations:
+  ✓ Notion: enabled (5/5 env vars set)
+  ✓ Google Calendar: enabled (2/2 env vars set)
+  ✗ YNAB: disabled (0/2 env vars set)
+  ✗ AnyList: disabled (not configured)
+  ✗ Outlook: disabled (not configured)
+  ✗ Recipes: disabled (0/3 env vars set)
+
+Summary: READY TO DEPLOY
+  Required: 8/8 checks passed
+  Integrations: 2 enabled, 4 disabled
+  Tools available: 23/70
+```
+
+### Error Output
+
+```
+=== Family Meeting Setup Validation ===
+
+Family Config: config/family.yaml
+  ✗ ERROR: Missing required field 'family.partners' (at least one partner required)
+
+Environment: .env
+  ✗ ERROR: ANTHROPIC_API_KEY not set
+    → Get your API key at https://console.anthropic.com/
+  ✗ WARNING: PARTNER1_PHONE format invalid: "+15551234567" (remove + prefix)
+
+Integrations:
+  ⚠ Notion: partially configured (3/5 env vars set)
+    Missing: NOTION_MEAL_PLANS_DB, NOTION_MEETINGS_DB
+    → See: docs/notion-setup.md Step 3
+
+Summary: NOT READY
+  Required: 6/8 checks passed (2 errors)
+  Fix the errors above before deploying.
+```
+
+## Behavior
+
+1. Reads family.yaml — validates structure, required fields, timezone validity
+2. Reads .env — checks all required env vars, validates format patterns
+3. Cross-references phone numbers between .env and family.yaml partner count
+4. Checks each integration group for completeness (all-or-nothing)
+5. Reports summary with tool count based on enabled integrations
+6. Exit code: 0 = ready, 1 = errors found

--- a/specs/030-quick-start-onboarding/data-model.md
+++ b/specs/030-quick-start-onboarding/data-model.md
@@ -1,0 +1,58 @@
+# Data Model: Quick Start Onboarding
+
+**Feature**: 030-quick-start-onboarding
+**Date**: 2026-03-09
+
+## Entities
+
+### Integration
+
+Represents a configurable external service connection.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| name | string | Unique identifier (e.g., "notion", "google_calendar", "ynab") |
+| display_name | string | Human-readable name (e.g., "Notion", "Google Calendar") |
+| required | boolean | Whether the integration is required for the app to start (only whatsapp and ai_api are required) |
+| env_vars | list[string] | Environment variables needed to enable this integration (all must be present) |
+| tools | list[string] | Tool names associated with this integration |
+| system_prompt_tag | string | Tag used in system prompt frontmatter to identify sections for this integration |
+| health_check | callable or None | Function to verify live connectivity (None for env-var-only checks) |
+| status | enum | Runtime status: "enabled", "disabled", "partial", "error" |
+
+**Status transitions**:
+- `disabled` → `enabled`: Operator adds all required env vars and restarts
+- `enabled` → `disabled`: Operator removes env vars and restarts
+- `enabled` → `error`: Integration configured but connectivity check fails at runtime
+- `partial`: Some but not all required env vars are set (treated as disabled with a warning)
+
+### IntegrationGroup
+
+Predefined set of integrations with their configuration.
+
+| Integration | Required Env Vars | Tools Count | System Prompt Files |
+|-------------|-------------------|-------------|---------------------|
+| core | *(always enabled — no env vars)* | ~3 tools (preferences, daily context) | 01-identity.md, 02-response-rules.md, 05-chores-nudges.md |
+| whatsapp | WHATSAPP_PHONE_NUMBER_ID, WHATSAPP_ACCESS_TOKEN, WHATSAPP_VERIFY_TOKEN, WHATSAPP_APP_SECRET | 0 (infrastructure) | *(none — infrastructure only)* |
+| ai_api | ANTHROPIC_API_KEY | 0 (infrastructure) | 01-identity.md |
+| notion | NOTION_TOKEN, NOTION_ACTION_ITEMS_DB, NOTION_MEAL_PLANS_DB, NOTION_MEETINGS_DB, NOTION_FAMILY_PROFILE_PAGE | ~14 tools | 03-daily-planner.md (partial) |
+| google_calendar | GOOGLE_CALENDAR_FAMILY_ID + GOOGLE_TOKEN_JSON | ~7 tools | 03-daily-planner.md (partial), 07-calendar-reminders.md, 09-forward-to-calendar.md |
+| outlook | OUTLOOK_CALENDAR_ICS_URL | 1 tool | 03-daily-planner.md (partial) |
+| ynab | YNAB_ACCESS_TOKEN, YNAB_BUDGET_ID | ~5 tools | 06-budget.md, 10-receipt-categorization.md |
+| anylist | ANYLIST_SIDECAR_URL (with reachable sidecar) | 1 tool | 04-grocery-recipes.md (partial) |
+| recipes | NOTION_RECIPES_DB, NOTION_COOKBOOKS_DB, R2_ACCOUNT_ID | ~5 tools | 04-grocery-recipes.md (partial) |
+
+## Relationships
+
+- An **Integration** has many **Tools** (1:N)
+- An **Integration** tags many **System Prompt Sections** (1:N via frontmatter)
+- A **Tool Description** belongs to one **Integration** (N:1)
+- The **Health Endpoint** queries all enabled **Integrations** for status
+
+## Validation Rules
+
+- Required integrations (whatsapp, ai_api) must be enabled — app exits on startup if missing
+- Optional integrations are all-or-nothing: all env vars for a group must be set, or none
+- Partial configuration (some env vars set) triggers a warning and the integration is treated as disabled
+- Phone numbers: digits only, 10-15 characters, no + prefix
+- API keys: format-checked by prefix pattern (e.g., `sk-ant-` for Anthropic)

--- a/specs/030-quick-start-onboarding/plan.md
+++ b/specs/030-quick-start-onboarding/plan.md
@@ -1,0 +1,175 @@
+# Implementation Plan: Quick Start Onboarding
+
+**Branch**: `030-quick-start-onboarding` | **Date**: 2026-03-09 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/030-quick-start-onboarding/spec.md`
+
+## Summary
+
+Enable minimal WhatsApp + AI deployments by dynamically filtering tools and system prompt sections based on configured integrations. Add a validation script that cross-references family.yaml and .env to catch configuration errors before deployment. Fix health endpoint to report "healthy" for minimal deployments.
+
+**Core approach**: Centralized integration registry → drives tool filtering, prompt filtering, health checks, and validation. YAML frontmatter tags on system prompt files. Auto-detect enabled integrations from env vars.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: FastAPI, anthropic SDK, PyYAML (existing)
+**Storage**: JSON files in `data/` (unchanged)
+**Testing**: pytest
+**Target Platform**: Linux server (Railway), Docker
+**Project Type**: Web service (existing codebase enhancement)
+**Performance Goals**: Startup time < 5s (current baseline), no per-request overhead for integration detection
+**Constraints**: Single uvicorn worker (APScheduler), backward compatible with existing full deployments
+**Scale/Scope**: 6 integration groups, ~70 tools, 9 system prompt files, 13 tool description files
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Integration Over Building | PASS | Feature enhances integration management, doesn't rebuild anything |
+| II. Mobile-First Access | PASS | No UI changes — WhatsApp remains the interface |
+| III. Simplicity & Low Friction | PASS | Reduces operator setup friction. End users unaffected. |
+| IV. Structured Output | N/A | No output format changes |
+| V. Incremental Value | PASS | Core design principle of this feature — each integration adds standalone value |
+
+**Post-design re-check**: All gates still pass. The integration registry adds one new file (`src/integrations.py`) but simplifies the overall system by centralizing scattered detection logic.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/030-quick-start-onboarding/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── validate-setup-cli.md
+│   └── health-endpoint.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── integrations.py          # NEW — centralized integration registry
+├── config.py                # MODIFIED — use registry for integration detection
+├── assistant.py             # MODIFIED — dynamic tool filtering at startup
+├── app.py                   # MODIFIED — health endpoint logic
+├── prompts/
+│   ├── __init__.py          # MODIFIED — frontmatter parsing, conditional loading
+│   ├── system/
+│   │   ├── 01-identity.md   # MODIFIED — add frontmatter (requires: [core])
+│   │   ├── 02-response-rules.md  # MODIFIED — add frontmatter (requires: [core])
+│   │   ├── 03-daily-planner.md   # MODIFIED — split or add frontmatter
+│   │   ├── ...              # Each file gets frontmatter tags
+│   │   └── 10-receipt-categorization.md
+│   └── tools/
+│       ├── calendar.md      # Unchanged (filtered by tool name, not file)
+│       └── ...
+
+scripts/
+└── validate_setup.py        # NEW — pre-deployment validation CLI
+
+tests/
+├── test_integrations.py     # NEW — integration registry tests
+├── test_validate_setup.py   # NEW — validation script tests
+└── test_prompts.py          # MODIFIED — test prompt filtering
+```
+
+**Structure Decision**: Single project, existing directory structure. One new module (`src/integrations.py`), one new script (`scripts/validate_setup.py`), two new test files.
+
+## Implementation Phases
+
+### Phase 1: Integration Registry (Foundation)
+
+Create `src/integrations.py` with:
+- `INTEGRATION_REGISTRY` dict mapping integration names to env vars, tools, and prompt tags
+- `get_enabled_integrations() -> set[str]` — checks env vars, returns enabled integration names
+- `get_tools_for_integrations(enabled: set[str]) -> list[str]` — returns tool names for enabled integrations
+- `is_integration_enabled(name: str) -> bool` — convenience check
+
+Update `src/config.py`:
+- Replace `OPTIONAL_GROUPS` with reference to registry
+- Add `ENABLED_INTEGRATIONS: set[str]` computed at startup
+- Log enabled/disabled integrations using registry
+
+### Phase 2: Tool Filtering
+
+Update `src/assistant.py`:
+- Import `ENABLED_INTEGRATIONS` from config
+- Build `TOOLS` list dynamically: include only tools whose integration is enabled
+- Build `TOOL_FUNCTIONS` dict to match filtered tools
+- Add `_ALL_TOOLS` for reference (full list) and `TOOLS` (filtered)
+
+Update `src/prompts/__init__.py`:
+- Modify `load_tool_descriptions()` to accept `enabled_integrations` parameter
+- Filter tool descriptions to only include enabled tools
+- Modify `render_tool_descriptions()` accordingly
+
+### Phase 3: System Prompt Filtering
+
+Add YAML frontmatter to each system prompt file:
+```yaml
+---
+requires: [core]
+---
+```
+or
+```yaml
+---
+requires: [notion, google_calendar]
+---
+```
+
+Update `src/prompts/__init__.py`:
+- `load_system_prompt()` accepts `enabled_integrations: set[str]`
+- Parse YAML frontmatter from each .md file (manual parsing, no new dependency)
+- Skip files whose `requires` list contains any integration not in `enabled_integrations`
+- Strip frontmatter before concatenation
+- Clear `@lru_cache` or make cache key include enabled integrations
+
+Handle multi-integration prompt files (e.g., `03-daily-planner.md` references Notion, Calendar, and Outlook):
+- Option A: Split into separate files per integration
+- Option B: Tag with all required integrations, include if ANY are enabled
+- **Decision**: Option B — tag with `requires_any: [notion, google_calendar, outlook]`. Include if at least one is enabled. The prompt text uses `{placeholder}` for names which are already handled.
+
+### Phase 4: Health Endpoint Fix
+
+Update `src/app.py` health endpoint:
+- Change status logic: "degraded" only if a *configured* optional integration is failing
+- Unconfigured integrations (`configured: false`) excluded from status calculation
+- ~2-line change to existing logic
+
+### Phase 5: Validation Script
+
+Create `scripts/validate_setup.py`:
+- Reads family.yaml (validates structure, required fields, timezone)
+- Reads .env (via dotenv) — checks required vars, format patterns
+- Cross-references integration registry for completeness
+- Reports per-integration status
+- Exit code 0/1
+- See `contracts/validate-setup-cli.md` for full output spec
+
+### Phase 6: Testing & Documentation
+
+- Add `tests/test_integrations.py` — registry correctness, enable/disable logic
+- Add `tests/test_validate_setup.py` — validation script coverage
+- Update `tests/test_prompts.py` — prompt filtering tests
+- Update ONBOARDING.md — add "Quick Start" section at top pointing to validation script
+- Update CLAUDE.md — document integration registry
+
+## Key Design Decisions
+
+1. **Auto-detect from env vars, not explicit YAML declaration**: Operator doesn't need to declare `integrations: [notion]` in family.yaml. The registry checks env vars and determines what's enabled. Less configuration, less drift.
+
+2. **Frontmatter parsing without new dependencies**: Simple regex-based YAML frontmatter parsing (~10 lines). No `python-frontmatter` package needed. Pattern: strip everything between first `---` and second `---` at file start.
+
+3. **`requires_any` semantics for multi-integration prompts**: A prompt file tagged `requires_any: [notion, google_calendar]` is included if at least one of those integrations is enabled. This handles `03-daily-planner.md` which covers multiple integrations.
+
+4. **Tools filtered at module load time**: `TOOLS` list built once at import. No per-request overhead. Changes require restart (which is the only way to change env vars anyway).
+
+5. **Backward compatible**: Existing deployments with all integrations configured see zero behavior change. No new required config fields.

--- a/specs/030-quick-start-onboarding/quickstart.md
+++ b/specs/030-quick-start-onboarding/quickstart.md
@@ -1,0 +1,93 @@
+# Quickstart: Testing Feature 030
+
+## Prerequisites
+- Working development environment with Python 3.12+
+- Valid `.env` file with at least ANTHROPIC_API_KEY and WHATSAPP_* vars
+- `config/family.yaml` from example template
+
+## Test Scenarios
+
+### 1. Validation Script (US1, US3)
+
+```bash
+# Happy path — full config
+python scripts/validate_setup.py
+# Expected: "READY TO DEPLOY" with all integrations listed
+
+# Missing required var
+# Remove ANTHROPIC_API_KEY from .env, then:
+python scripts/validate_setup.py
+# Expected: Exit code 1, error message about missing key
+
+# Partial integration
+# Set NOTION_TOKEN but remove NOTION_ACTION_ITEMS_DB from .env, then:
+python scripts/validate_setup.py
+# Expected: Warning about partial Notion configuration
+```
+
+### 2. Dynamic Tool Filtering (US2)
+
+```bash
+# Start app with minimal config (only WhatsApp + Anthropic)
+# Remove all Notion/Calendar/YNAB vars from .env
+TESTING=1 python -c "
+from src.config import FAMILY_CONFIG
+from src.integrations import get_enabled_integrations
+enabled = get_enabled_integrations()
+print('Enabled:', [i.name for i in enabled])
+print('Disabled:', [name for name in ALL_INTEGRATIONS if name not in enabled])
+"
+
+# Verify tool count
+TESTING=1 python -c "
+from src.assistant import TOOLS
+print(f'Tools registered: {len(TOOLS)}')
+for t in TOOLS:
+    print(f'  - {t[\"name\"]}')
+"
+# Expected: Only core tools (preferences, daily context), no Notion/Calendar/YNAB tools
+```
+
+### 3. Health Endpoint (US4)
+
+```bash
+# Start app with minimal config
+uvicorn src.app:app --host 0.0.0.0 --port 8000 &
+
+# Check health
+curl -s http://localhost:8000/health | python3 -m json.tool
+# Expected: "status": "healthy" (not "degraded") with unconfigured integrations showing "configured": false
+```
+
+### 4. System Prompt Filtering (US2)
+
+```bash
+# Verify system prompt sections are filtered
+TESTING=1 python -c "
+from src.prompts import load_system_prompt
+from src.integrations import get_enabled_integrations
+enabled = get_enabled_integrations()
+prompt = load_system_prompt(enabled_integrations=enabled)
+print(f'Prompt length: {len(prompt)} chars')
+# Check that Notion/Calendar sections are excluded
+assert 'action items' not in prompt.lower() or 'notion' in [i.name for i in enabled]
+print('PASS: Prompt correctly filtered')
+"
+```
+
+### 5. End-to-End (All US)
+
+```bash
+# Full deployment with minimal config → send WhatsApp message
+# 1. Run validation
+python scripts/validate_setup.py
+
+# 2. Start app
+uvicorn src.app:app --host 0.0.0.0 --port 8000
+
+# 3. Send test message asking about calendar (not configured)
+# Expected: Bot gracefully explains calendar isn't set up
+
+# 4. Add Google Calendar vars to .env, restart
+# Expected: Bot now offers calendar features
+```

--- a/specs/030-quick-start-onboarding/research.md
+++ b/specs/030-quick-start-onboarding/research.md
@@ -1,0 +1,110 @@
+# Research: Quick Start Onboarding
+
+**Feature**: 030-quick-start-onboarding
+**Date**: 2026-03-09
+
+## R1: Conditional System Prompt Assembly
+
+**Decision**: Python-side filter using YAML frontmatter metadata tags in Markdown files.
+
+**Rationale**: At our scale (9 system prompt files, 13 tool description files, 6 integration groups), YAML frontmatter provides the best balance of simplicity, self-documentation, and zero new dependencies. Each prompt file declares its required integrations via a `requires:` field in YAML frontmatter. The loader strips frontmatter before concatenation and skips files whose requirements aren't met. This is ~15-25 lines of code change to `src/prompts/__init__.py`.
+
+**Alternatives considered**:
+- **Convention-based filename mapping** (e.g., `06-budget.md` → requires YNAB): Simpler but fragile — survives poorly when files are renamed or when one file covers multiple integrations. No self-documentation.
+- **Jinja2 templating**: Overkill. Adds a dependency and new syntax. Only worthwhile for intra-section conditionals (e.g., "show Outlook paragraph only if configured"), which we don't need — our file boundaries already map to integration groups.
+- **Dynamic/just-in-time loading**: Pattern from Anthropic's agent skills guidance. Not applicable to our static system prompt chatbot model.
+
+**Key pitfall — prompt coherence**: Removing sections can break cross-references ("the action items mentioned above" when the Notion section was filtered out). Mitigation: make each section self-contained, keep identity (01) and response rules (02) as always-included, and add a stub line for disabled integrations so the bot knows what's not available.
+
+**Sources**:
+- [Anthropic: Effective Context Engineering](https://www.anthropic.com/engineering/effective-context-engineering-for-ai-agents)
+- [PromptLayer: Prompt Coherence](https://www.promptlayer.com/glossary/prompt-coherence)
+- [Banks: Jinja2-based LLM Prompt Management](https://github.com/masci/banks)
+
+## R2: Integration Registry Architecture
+
+**Decision**: Centralized integration registry in `src/integrations.py` — a single dict mapping integration names to their required env vars, associated tools, associated system prompt files, and associated tool description sections.
+
+**Rationale**: Currently integration detection is scattered: `OPTIONAL_GROUPS` in `config.py` knows env vars, `assistant.py` has the static tools list, `prompts/__init__.py` loads all prompts unconditionally, and the health endpoint has its own hardcoded integration checks. A single registry normalizes all of this.
+
+**Registry structure** (conceptual):
+```python
+INTEGRATIONS = {
+    "notion": {
+        "env_vars": ["NOTION_TOKEN", "NOTION_ACTION_ITEMS_DB", ...],
+        "tools": ["get_action_items", "add_action_item", ...],
+        "system_prompts": ["03-daily-planner.md"],  # or use frontmatter
+        "tool_files": ["notion.md", "proactive.md"],
+        "health_check": check_notion_health,
+    },
+    "google_calendar": { ... },
+    ...
+}
+```
+
+**Alternatives considered**:
+- **Keep detection distributed**: Each module checks its own config. Leads to inconsistency (health endpoint might report Notion as "not configured" while the tools list still includes Notion tools).
+- **family.yaml declares integrations explicitly**: User would add `integrations: [notion, google_calendar]` to YAML. Adds manual step that can drift from .env reality. Better to auto-detect from env vars and use the registry as the source of truth.
+
+**Decision**: Auto-detect enabled integrations from env vars using the registry, rather than requiring explicit declaration in family.yaml. This means the operator only needs to add credentials to .env — no need to also declare them in family.yaml.
+
+## R3: Setup/Validation Command Design
+
+**Decision**: Single Python script `scripts/validate_setup.py` that reads both family.yaml and .env, cross-references against the integration registry, and reports readiness.
+
+**Rationale**: A validation-focused command is more useful than a generator. The operator still fills in family.yaml and .env manually (they already do this), but the validation command catches errors before deployment. This avoids the complexity of generating .env from YAML while delivering the core value: "did I configure everything correctly?"
+
+**What it checks**:
+1. family.yaml parses correctly with all required fields
+2. Required env vars are present (ANTHROPIC_API_KEY, WHATSAPP_*)
+3. Phone numbers match expected format (digits only, 10-15 chars)
+4. API keys match expected format patterns (sk-ant-* for Anthropic, etc.)
+5. Optional integration groups are all-or-nothing (no partial configs)
+6. Reports enabled/disabled/partial integrations summary
+
+**Alternatives considered**:
+- **Generate .env from YAML**: Attractive but introduces security concerns (credentials in YAML) and the split-file decision (from clarification) makes this moot.
+- **Interactive wizard**: Out of scope per spec.
+
+## R4: Health Endpoint "Healthy" vs "Degraded" Logic
+
+**Decision**: Change health logic so "degraded" only applies to integrations that are both *configured* AND *failing*. Unconfigured integrations are reported as `"status": "not_configured"` and do not affect the overall status.
+
+**Current logic** (`src/app.py` lines 419-428):
+```python
+optional_ok = all(i["connected"] for i in integrations if not i["required"] and i["configured"])
+if not optional_ok:
+    status = "degraded"
+```
+
+**New logic**:
+```python
+configured_optional = [i for i in integrations if not i["required"] and i["configured"]]
+optional_ok = all(i["connected"] for i in configured_optional)
+# If no optional integrations are configured, optional_ok is True (vacuous truth)
+```
+
+This is a 2-line change. Unconfigured integrations already show `"configured": false` in the response — they just need to stop affecting the status calculation.
+
+## R5: Tool Filtering Mechanism
+
+**Decision**: Filter the `TOOLS` list at startup time based on enabled integrations. Build `TOOLS` dynamically instead of statically.
+
+**Current state**: `TOOLS` is a module-level list of ~70 tool dicts defined statically in `assistant.py` lines 51-1265. All tools are always included.
+
+**New approach**:
+1. Tag each tool with its required integration (via the integration registry or inline metadata)
+2. At module load time, check which integrations are enabled
+3. Build `TOOLS` by filtering the full list to only include tools for enabled integrations
+4. `TOOL_FUNCTIONS` dict (lines 1428-1587) also filtered to match
+
+**Why startup-time, not per-request**: Claude's tool list is fixed per conversation. Changing it mid-conversation is not supported. Since integrations can only change on restart (env vars), filtering at startup is correct.
+
+**Tool-to-integration mapping** (derived from tool description files):
+- `notion`: get_action_items, add_action_item, complete_action_item, rollover_incomplete_items, get_family_profile, update_family_profile, add_topic, create_meeting, save_meal_plan, get_meal_plan, get_backlog_items, add_backlog_item, complete_backlog_item, get_routine_templates
+- `google_calendar`: get_calendar_events, write_calendar_blocks, create_quick_event, delete_calendar_event, list_recurring_events, batch_create_events, batch_delete_events
+- `outlook`: get_outlook_events
+- `ynab`: get_budget_summary, search_transactions, recategorize_transaction, create_transaction, update_category_budget
+- `anylist`: push_grocery_list
+- `recipes` (requires notion + r2): extract_and_save_recipe, search_recipes, get_recipe_details, recipe_to_grocery_list, list_cookbooks
+- `core` (always available): get_daily_context, save_preference, list_preferences, remove_preference, get_drive_times

--- a/specs/030-quick-start-onboarding/spec.md
+++ b/specs/030-quick-start-onboarding/spec.md
@@ -1,0 +1,140 @@
+# Feature Specification: Quick Start Onboarding
+
+**Feature Branch**: `030-quick-start-onboarding`
+**Created**: 2026-03-09
+**Status**: Draft
+**Input**: User description: "No Quick Start path. Currently 8 steps across 4 platforms (3-4 hours). Need a minimal setup: WhatsApp + AI only (~30 min) with integrations as optional add-ons. Automate as much as possible — operator fills in a YAML file and the system does the rest."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Automated Setup from Config File (Priority: P1)
+
+An operator fills in family.yaml with family details and preferences (committed to git), and .env with credentials and API keys (not committed). They run a validation script that validates both files together, checks integration completeness, and reports readiness. The operator then deploys with one command. The validation script cross-references family.yaml and .env to ensure all required values are present for configured integrations. Future enhancement: support secrets managers (e.g., HashiCorp Vault) as an alternative credential source.
+
+**Why this priority**: This is the highest-impact change. Today operators must manually edit both family.yaml AND .env with no automated cross-validation. A validation script that validates both files together, detects partial integration configs, and reports exactly what's ready eliminates the most error-prone part of setup.
+
+**Independent Test**: Fill in family.yaml with test values (API keys, phone numbers, integration credentials). Run the validation script. Verify it validates both files and reports what integrations are enabled. Deploy and send a WhatsApp message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a filled-in family.yaml with required fields (API keys, WhatsApp credentials, phone numbers), **When** the operator runs the validation script, **Then** it validates the .env file and reports all checks passed.
+2. **Given** a family.yaml with only minimal required fields (Anthropic key, WhatsApp credentials, partner phones), **When** the operator runs the validation script, **Then** it confirms only required vars are present, reports which optional integrations are disabled, and reports "Minimal deployment ready."
+3. **Given** a family.yaml with a Notion token but missing database IDs, **When** the operator runs the validation script, **Then** it warns that Notion is partially configured and lists the missing database IDs.
+4. **Given** a family.yaml with an invalid phone number format, **When** the operator runs the validation script, **Then** it reports the specific validation error with the expected format.
+
+---
+
+### User Story 2 - Bot Adapts to Configured Integrations (Priority: P1)
+
+When integrations are not configured, the bot must not reference unavailable features in its system prompt or attempt unavailable tool calls. If Notion is not set up, the bot should not offer to "add that to your action items." The bot's available tools and system prompt dynamically reflect what's actually configured, so a minimal deployment feels intentional — not broken.
+
+**Why this priority**: Tied with US1 because a minimal deployment that constantly references unavailable features feels broken. This is essential for the Quick Start experience to feel polished and professional.
+
+**Independent Test**: Deploy with only WhatsApp + AI configured. Send messages that would normally trigger Notion/Calendar/YNAB tools (e.g., "what's on my calendar today?"). The bot should gracefully explain it doesn't have calendar access, rather than attempting a tool call that fails.
+
+**Acceptance Scenarios**:
+
+1. **Given** a deployment without Google Calendar configured, **When** a user asks "what's on my calendar?", **Then** the bot responds that calendar integration is not set up, without attempting the calendar tool call.
+2. **Given** a deployment without Notion configured, **When** a user asks to add an action item, **Then** the bot acknowledges the request but explains task management is not available in this deployment.
+3. **Given** a deployment with all integrations configured, **When** a user asks about their calendar, **Then** the bot uses the calendar tool as it does today (no regression).
+4. **Given** a minimal deployment, **When** the bot generates its tool list, **Then** tools for unconfigured integrations are excluded entirely — they do not appear in the system prompt.
+
+---
+
+### User Story 3 - Pre-Deployment Validation (Priority: P2)
+
+Before deploying, the operator runs a validation command that checks all configuration is correct: required env vars exist, API key formats are valid, family.yaml parses correctly, phone numbers are in expected format, and optional integrations are properly configured (all-or-nothing per integration group). This catches errors before they result in a failed deployment.
+
+**Why this priority**: Prevents the most common failure mode (deploy, wait for startup, discover misconfiguration, fix, redeploy). Important but not blocking — an operator can deploy without validation and rely on health endpoint and startup logs.
+
+**Independent Test**: Run the validation tool with intentionally incorrect config (missing API key, malformed phone number, partial Notion setup) and verify it reports each error clearly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a correctly configured environment, **When** the operator runs validation, **Then** it reports all checks passed with a summary of enabled integrations.
+2. **Given** a missing required env var (e.g., ANTHROPIC_API_KEY), **When** the operator runs validation, **Then** it identifies the variable, explains what it's for, and shows which family.yaml field maps to it.
+3. **Given** a partial integration setup (e.g., NOTION_TOKEN set but NOTION_ACTION_ITEMS_DB missing), **When** the operator runs validation, **Then** it reports the integration as "partially configured" and lists specific missing values.
+
+---
+
+### User Story 4 - Health Endpoint Reflects Configured State (Priority: P2)
+
+The health endpoint reports "healthy" when all configured integrations are working, rather than "degraded" when optional integrations are simply not configured. An operator with a minimal deployment should see "healthy" status, not be alarmed by a "degraded" status for integrations they intentionally chose not to set up.
+
+**Why this priority**: Quality-of-life improvement. A "degraded" health status for a minimal deployment creates unnecessary concern and confusion.
+
+**Independent Test**: Deploy with only WhatsApp + AI. Hit the health endpoint. Verify it returns "healthy" with unconfigured integrations listed as "not configured" (not "failing").
+
+**Acceptance Scenarios**:
+
+1. **Given** a minimal deployment (WhatsApp + AI only), **When** the operator checks the health endpoint, **Then** it returns "healthy" status.
+2. **Given** a full deployment with all integrations, **When** one optional integration fails (e.g., Notion API is down), **Then** it returns "degraded" as it does today.
+3. **Given** a deployment where an integration is configured but failing, **When** the operator checks health, **Then** the failing integration shows as "configured: true, connected: false" with the error — distinct from "configured: false."
+
+---
+
+### Edge Cases
+
+- What happens when an operator deploys with zero configuration (no family.yaml, no .env)? The app should fail at startup with a clear error pointing to the validation script.
+- What happens when an operator partially configures an integration (e.g., sets NOTION_TOKEN but not database IDs)? The validation tool should warn, and at runtime the integration should be treated as disabled with a startup log warning.
+- What happens when an operator removes an integration that was previously configured (deletes env vars and restarts)? The bot should immediately stop offering those features with no leftover tool references.
+- What happens when family.yaml contains credentials for an integration the operator hasn't provisioned yet (e.g., a placeholder Google Calendar ID)? Validation should distinguish between "missing" and "invalid format."
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST use family.yaml for family identity and preferences (safe to commit) and .env for credentials and secrets (never committed). The validation script validates both files together as a unified configuration surface.
+- **FR-002**: The system MUST provide a validation script that reads family.yaml, cross-references .env, validates all configuration, and reports deployment readiness — including which integrations are enabled, disabled, or partially configured.
+- **FR-003**: The system MUST function as a useful conversational assistant with only WhatsApp and Anthropic API configured — no other integrations required.
+- **FR-004**: The system MUST dynamically exclude tools for unconfigured integrations from the assistant's available tool set and system prompt at startup. System prompt sections are tagged with their required integration and filtered at load time — sections for disabled integrations are omitted entirely.
+- **FR-005**: The bot MUST NOT attempt tool calls for unconfigured integrations, and MUST NOT reference unavailable features in its responses.
+- **FR-006**: The health endpoint MUST distinguish between "not configured" (operator choice) and "configured but failing" (error), and MUST report "healthy" when all configured integrations are operational.
+- **FR-007**: The system MUST provide a validation command that checks all configuration before deployment: env var presence, format validation, family.yaml parsing, and integration group completeness.
+- **FR-008**: The validation command MUST provide specific, actionable error messages for each issue found.
+- **FR-009**: Adding or removing an integration MUST require only updating env vars and restarting — no code changes or migrations.
+- **FR-010**: The system MUST log which integrations are enabled vs disabled at startup.
+- **FR-011**: The validation script MUST be idempotent — running it multiple times with the same configuration produces identical results with no side effects.
+
+### Key Entities
+
+- **Integration**: A configurable external service (e.g., Notion, Google Calendar, YNAB). Has a name, required credential fields, enabled/disabled status, and associated bot tools. Integrations are all-or-nothing: either fully configured or fully disabled.
+- **Operator**: The person deploying and managing the assistant for a family. Fills in family.yaml, runs the setup/validation commands, deploys to Railway.
+- **family.yaml**: Configuration file for family identity (names, timezone, preferences) and integration declarations (which integrations are desired). Safe to commit to version control. Drives the bot's personality and declares which features should be enabled.
+- **.env**: Credentials file for API keys, tokens, and secrets. Never committed to version control. Provides the sensitive values that family.yaml's integration declarations require. Future: may be replaced by a secrets manager (e.g., HashiCorp Vault).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A new operator completes setup and exchanges their first WhatsApp message within 30 minutes (excluding Meta Business verification wait time).
+- **SC-002**: Operator fills in two files (family.yaml for identity, .env for credentials) and runs one command to validate and report deployment readiness.
+- **SC-003**: A minimal deployment (WhatsApp + AI only) passes the health check as "healthy" with zero integration-related errors in startup logs.
+- **SC-004**: When an integration is not configured, 0% of bot responses reference that integration's features.
+- **SC-005**: The validation command catches 100% of missing required fields, malformed values, and partial integration configurations before deployment.
+- **SC-006**: An operator can add any single integration by adding credentials to .env, running the validation script, and restarting — under 15 minutes per integration.
+
+## Clarifications
+
+### Session 2026-03-09
+
+- Q: Should credentials live in family.yaml (convenient) or .env (secure)? → A: Split approach — family.yaml for identity/preferences (committed to git), .env for credentials/secrets (not committed). Setup command validates both. Future enhancement: support secrets managers (e.g., HashiCorp Vault) for sensitive values.
+- Q: How should the system prompt handle unconfigured integrations? → A: Tag prompt sections with required integrations; filter at load time (omit sections for disabled integrations). Research best practices and tradeoffs for Markdown-based prompt management at scale during planning phase.
+
+## Assumptions
+
+- Meta Business verification and WhatsApp Business API provisioning are external dependencies with variable wait times (hours to days). The Quick Start guide clearly flags this as a prerequisite completed before starting the timer.
+- Railway remains the primary deployment platform. The setup automation targets Railway.
+- Credentials stay in .env (not family.yaml) for security. family.yaml may declare which integrations are desired, but secrets are always sourced from .env or a secrets manager.
+- Google Calendar OAuth still requires an interactive browser flow (setup_calendar.py) — this cannot be fully automated via YAML. The validation script handles everything except OAuth flows, which are flagged as manual steps.
+- Markdown-based prompt management (9 numbered files, tag-and-filter) is sufficient for the current scale (~6 integration groups, ~22 tools). Planning phase should research best practices and tradeoffs for this approach vs alternatives if feature count grows significantly.
+- The Anthropic API key is readily obtainable by operators (sign up at console.anthropic.com, generate key).
+
+## Out of Scope
+
+- Multi-tenant deployments (one instance serving multiple families).
+- Automated Notion database schema creation (Notion API limitation).
+- Automated WhatsApp Business API provisioning (requires manual Meta Business verification).
+- Interactive setup wizard or web-based configuration UI — the YAML file approach is sufficient.
+- One-click deploy buttons (Railway template marketplace).
+- Operator dashboard for managing multiple family deployments.

--- a/specs/030-quick-start-onboarding/tasks.md
+++ b/specs/030-quick-start-onboarding/tasks.md
@@ -1,0 +1,170 @@
+# Tasks: Quick Start Onboarding
+
+**Input**: Design documents from `/specs/030-quick-start-onboarding/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Branch creation and orientation
+
+- [X] T001 Checkout feature branch `030-quick-start-onboarding` and verify existing spec artifacts
+
+---
+
+## Phase 2: Foundational — Integration Registry
+
+**Purpose**: Centralized integration registry that maps integrations → env vars, tools, prompt tags. Drives all downstream filtering, health checks, and validation.
+
+**⚠️ CRITICAL**: All user stories depend on this registry being complete.
+
+- [X] T002 Create src/integrations.py with INTEGRATION_REGISTRY dict mapping each integration (core, whatsapp, ai_api, notion, google_calendar, outlook, ynab, anylist, recipes) to its display_name, required flag, env_vars list, tools list, and system_prompt_tag. "core" is a pseudo-integration that is always enabled (no env vars required) — it represents base tools (preferences, daily context) and prompt sections (identity, response rules, chores/nudges) available in every deployment. Include get_enabled_integrations(), get_tools_for_integrations(), and is_integration_enabled() functions. Reference data-model.md IntegrationGroup table for env var and tool mappings.
+- [X] T003 Update src/config.py to import integration registry: add ENABLED_INTEGRATIONS set computed at startup via get_enabled_integrations(), replace or augment OPTIONAL_GROUPS with registry-based detection, log enabled/disabled integrations at module load time.
+
+**Checkpoint**: Integration registry available — `get_enabled_integrations()` returns correct set based on env vars.
+
+---
+
+## Phase 3: User Story 2 — Bot Adapts to Configured Integrations (Priority: P1) 🎯 MVP
+
+**Goal**: Tools and system prompt sections dynamically reflect only configured integrations. A minimal deployment (WhatsApp + AI) feels intentional, not broken.
+
+**Independent Test**: Deploy with only ANTHROPIC_API_KEY and WHATSAPP_* vars set. Verify TOOLS list contains only core tools. Verify system prompt omits Notion/Calendar/YNAB sections. Send "what's on my calendar?" — bot explains calendar isn't set up (no tool call attempted).
+
+### Implementation for User Story 2
+
+- [X] T004 [P] [US2] Add YAML frontmatter `requires: [core]` to src/prompts/system/01-identity.md and src/prompts/system/02-response-rules.md
+- [X] T005 [P] [US2] Add YAML frontmatter `requires_any: [notion, google_calendar, outlook]` to src/prompts/system/03-daily-planner.md
+- [X] T006 [P] [US2] Add YAML frontmatter to remaining system prompt files: 04-grocery-recipes.md (requires_any: [anylist, recipes]), 05-chores-nudges.md (requires: [core]), 06-budget.md (requires: [ynab]), 07-calendar-reminders.md (requires: [google_calendar]), 08-meeting-notes.md (requires: [notion]), 09-forward-to-calendar.md (requires: [google_calendar]), 10-receipt-categorization.md (requires: [ynab]). Read each file first to confirm correct integration tag.
+- [X] T007 [US2] Update src/prompts/__init__.py: add _parse_frontmatter() helper to extract `requires` and `requires_any` tags from markdown files. Modify load_system_prompt() to accept enabled_integrations parameter, filter out sections whose requirements aren't met, strip frontmatter before concatenation. Handle lru_cache invalidation (make cache key include frozenset of enabled integrations or remove cache).
+- [X] T008 [US2] Update src/assistant.py: import ENABLED_INTEGRATIONS from config and get_tools_for_integrations from integrations. Build TOOLS list dynamically — include only tools whose integration is enabled. Build TOOL_FUNCTIONS dict to match filtered TOOLS. Keep _ALL_TOOLS reference for validation script use.
+- [X] T009 [US2] Update src/prompts/__init__.py: modify load_tool_descriptions() to accept enabled_integrations parameter. Filter tool description sections to include only tools for enabled integrations. Update render_tool_descriptions() to pass enabled_integrations through.
+
+**Checkpoint**: Minimal deployment loads only core tools and core prompt sections. Full deployment behavior unchanged.
+
+---
+
+## Phase 4: User Story 1 + User Story 3 — Setup & Validation (Priority: P1/P2)
+
+**Goal**: One CLI command validates family.yaml + .env together, reports deployment readiness, catches errors before deploy.
+
+**Independent Test**: Run `python scripts/validate_setup.py` with full config → "READY TO DEPLOY". Remove ANTHROPIC_API_KEY → exit code 1 with error. Set NOTION_TOKEN but remove NOTION_ACTION_ITEMS_DB → partial config warning. See contracts/validate-setup-cli.md for full output spec.
+
+### Implementation for User Stories 1 & 3
+
+- [X] T010 [US1] Create scripts/validate_setup.py with CLI arg parsing (--env-file, --config-file), family.yaml loading and validation (required fields: family name, bot name, timezone, partners), and .env loading via dotenv. Report section-by-section with checkmark/cross output per contracts/validate-setup-cli.md.
+- [X] T011 [US3] Add required env var validation to scripts/validate_setup.py: check ANTHROPIC_API_KEY (format: sk-ant-*), WHATSAPP_* vars (4 required), N8N_WEBHOOK_SECRET, PARTNER phone numbers (digits only, 10-15 chars). Provide actionable error messages with fix hints per contracts/validate-setup-cli.md.
+- [X] T012 [US1] [US3] Add integration group completeness checking to scripts/validate_setup.py: import INTEGRATION_REGISTRY, check each integration's env vars (all-or-nothing), report enabled/disabled/partial status, calculate tool count from registry, output summary with exit code 0 (ready) or 1 (errors).
+
+**Checkpoint**: `python scripts/validate_setup.py` catches all config errors before deployment.
+
+---
+
+## Phase 5: User Story 4 — Health Endpoint Reflects Configured State (Priority: P2)
+
+**Goal**: Health endpoint returns "healthy" for minimal deployments where optional integrations are intentionally unconfigured.
+
+**Independent Test**: Deploy with WhatsApp + AI only. `curl /health` → `{"status": "healthy", ...}` with unconfigured integrations showing `"configured": false`. See contracts/health-endpoint.md for response examples.
+
+### Implementation for User Story 4
+
+- [X] T013 [US4] Update health status determination logic in src/app.py: import ENABLED_INTEGRATIONS or is_integration_enabled from registry. Change status calculation so unconfigured optional integrations (configured: false) are excluded — "degraded" only when a configured optional integration is failing. ~2-line change per contracts/health-endpoint.md.
+
+**Checkpoint**: Minimal deployment health check returns "healthy" status.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Testing, documentation, and end-to-end validation
+
+- [X] T014 [P] Create tests/test_integrations.py: test INTEGRATION_REGISTRY completeness (all integrations have required fields), test get_enabled_integrations() with mocked env vars (full config, minimal config, partial config), test get_tools_for_integrations() returns correct tool lists.
+- [X] T015 [P] Create tests/test_validate_setup.py: test validation script with valid config, missing required vars, partial integration configs, invalid phone number format. Mock file reads and env.
+- [X] T016 [P] Update tests/test_prompts.py: test frontmatter parsing (_parse_frontmatter helper), test load_system_prompt() with different enabled_integrations sets, verify core sections always included and integration sections filtered correctly.
+- [X] T017 Update ONBOARDING.md: add "Quick Start (30 minutes)" section at top, reference validation script, document minimal vs full deployment paths.
+- [X] T018 Update CLAUDE.md: document integration registry pattern (src/integrations.py), prompt frontmatter convention, validation script usage.
+- [X] T019 Run quickstart.md validation scenarios end-to-end (validation script, tool filtering, health endpoint, system prompt filtering, full e2e).
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — **BLOCKS all user stories**
+- **US2 (Phase 3)**: Depends on Phase 2 — can run in parallel with Phases 4 and 5
+- **US1+US3 (Phase 4)**: Depends on Phase 2 — can run in parallel with Phases 3 and 5
+- **US4 (Phase 5)**: Depends on Phase 2 — can run in parallel with Phases 3 and 4
+- **Polish (Phase 6)**: Depends on Phases 3, 4, and 5
+
+### User Story Dependencies
+
+- **US2 (P1)**: After Foundational — no dependencies on other stories
+- **US1 + US3 (P1/P2)**: After Foundational — no dependencies on other stories
+- **US4 (P2)**: After Foundational — no dependencies on other stories
+
+### Within Each User Story
+
+- US2: Frontmatter tagging (T004–T006) before prompt filtering logic (T007). Tool filtering (T008) and tool description filtering (T009) depend on T007 being complete for consistent behavior.
+- US1+US3: Family config validation (T010) before env var checks (T011) before integration completeness (T012) — sequential build-up of the validation script.
+- US4: Single task (T013), no internal dependencies.
+
+### Parallel Opportunities
+
+- T004, T005, T006 — different prompt files, no conflicts
+- T014, T015, T016 — different test files, no conflicts
+- After Phase 2 completes: Phases 3, 4, and 5 can all start simultaneously
+
+---
+
+## Parallel Example: User Story 2
+
+```bash
+# Launch all frontmatter tasks together (different files):
+Task: "Add frontmatter to 01-identity.md, 02-response-rules.md" (T004)
+Task: "Add frontmatter to 03-daily-planner.md" (T005)
+Task: "Add frontmatter to remaining prompt files" (T006)
+
+# Then sequential prompt/tool filtering:
+Task: "Update load_system_prompt() with frontmatter parsing" (T007)
+Task: "Build TOOLS list dynamically in assistant.py" (T008)
+Task: "Filter tool descriptions by enabled integrations" (T009)
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US2 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Integration Registry (CRITICAL — blocks all stories)
+3. Complete Phase 3: US2 — Bot adapts to configured integrations
+4. **STOP and VALIDATE**: Deploy with minimal config, verify tools/prompts filtered
+5. Deploy — minimal deployment feels intentional, not broken
+
+### Incremental Delivery
+
+1. Setup + Foundational → Integration registry ready
+2. Add US2 → Filtered tools and prompts → Deploy (MVP!)
+3. Add US1+US3 → Validation script → Operators validate before deploy
+4. Add US4 → Health endpoint fix → "healthy" for minimal deployments
+5. Polish → Tests, docs, end-to-end validation
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] labels map tasks to user stories for traceability
+- Total: 19 tasks across 6 phases
+- The integration registry (Phase 2) is the single foundation that enables everything else
+- US2 is the true MVP — a minimal deployment that doesn't reference unavailable features
+- The validation script (US1+US3) and health fix (US4) add operator quality-of-life

--- a/src/app.py
+++ b/src/app.py
@@ -32,6 +32,7 @@ from src.config import (
     WHATSAPP_VERIFY_TOKEN,
     YNAB_ACCESS_TOKEN,
 )
+from src.integrations import is_integration_enabled
 from src.tools.calendar import delete_assistant_events
 from src.transcribe import MAX_DURATION_SECONDS, get_audio_duration, transcribe_voice_note
 from src.whatsapp import download_media, extract_message, send_message
@@ -390,8 +391,8 @@ async def health():
     else:
         integrations["ynab"] = {"required": False, "configured": False, "connected": False, "error": None}
 
-    # AnyList sidecar
-    if ANYLIST_SIDECAR_URL:
+    # AnyList sidecar — use registry to check if explicitly configured
+    if is_integration_enabled("anylist"):
         try:
             async with httpx.AsyncClient(timeout=5.0) as client:
                 resp = await client.get(f"{ANYLIST_SIDECAR_URL}/health")

--- a/src/assistant.py
+++ b/src/assistant.py
@@ -8,7 +8,16 @@ import httpx
 from anthropic import Anthropic
 
 from src import context, conversation, drive_times, preferences, routines
-from src.config import ALL_CALENDAR_NAMES, ANTHROPIC_API_KEY, DEFAULT_CALENDAR, FAMILY_CONFIG, PHONE_TO_NAME, TIMEZONE
+from src.config import (
+    ALL_CALENDAR_NAMES,
+    ANTHROPIC_API_KEY,
+    DEFAULT_CALENDAR,
+    ENABLED_INTEGRATIONS,
+    FAMILY_CONFIG,
+    PHONE_TO_NAME,
+    TIMEZONE,
+)
+from src.integrations import get_tools_for_integrations
 from src.prompts import render_system_prompt, render_tool_descriptions
 from src.tools import (
     amazon_sync,
@@ -46,9 +55,13 @@ _welcomed_phones: set[str] = set()
 # Tool definitions for Claude
 # ---------------------------------------------------------------------------
 
-_tool_descs = render_tool_descriptions(FAMILY_CONFIG) if FAMILY_CONFIG else {}
+# Compute enabled tools from integration registry
+_enabled_tool_names: set[str] = set(get_tools_for_integrations(ENABLED_INTEGRATIONS))
+_enabled_tools_frozen = frozenset(_enabled_tool_names)
 
-TOOLS = [
+_tool_descs = render_tool_descriptions(FAMILY_CONFIG, enabled_tools=_enabled_tools_frozen) if FAMILY_CONFIG else {}
+
+_ALL_TOOLS = [
     {
         "name": "get_calendar_events",
         "description": _tool_descs.get("get_calendar_events", "get_calendar_events"),
@@ -1264,6 +1277,12 @@ TOOLS = [
     },
 ]
 
+# Filter tools to only include those for enabled integrations
+TOOLS = [t for t in _ALL_TOOLS if t["name"] in _enabled_tool_names]
+logger.info(
+    "Tools: %d/%d enabled (integrations: %s)", len(TOOLS), len(_ALL_TOOLS), ", ".join(sorted(ENABLED_INTEGRATIONS))
+)
+
 # Color mapping for calendar blocks
 _COLOR_MAP = {
     "chores": calendar.COLOR_CHORES,
@@ -1586,6 +1605,9 @@ TOOL_FUNCTIONS = {
     "split_receipt_transaction": lambda **kw: receipt.split_receipt_transaction(kw.get("_phone", "")),
 }
 
+# Filter TOOL_FUNCTIONS to match enabled TOOLS
+TOOL_FUNCTIONS = {k: v for k, v in TOOL_FUNCTIONS.items() if k in _enabled_tool_names}
+
 
 def _handle_save_preference(**kw) -> str:
     """Handle save_preference tool — stores a lasting user preference."""
@@ -1723,7 +1745,13 @@ def handle_message(sender_phone: str, message_text: str, image_data: dict | None
     # so the model reliably attends to it (GitHub issue #2)
     # P2 fix (Feature 016): also injected into user message above as time_prefix
     date_line = now.strftime("**Right now:** %A, %B %-d, %Y at %-I:%M %p Pacific.")
-    system = date_line + "\n\n" + render_system_prompt(FAMILY_CONFIG) + "\n\n" + date_line
+    system = (
+        date_line
+        + "\n\n"
+        + render_system_prompt(FAMILY_CONFIG, enabled_integrations=frozenset(ENABLED_INTEGRATIONS))
+        + "\n\n"
+        + date_line
+    )
 
     # Inject user preferences into system prompt so Claude naturally honors them
     user_prefs = preferences.get_preferences(sender_phone)

--- a/src/config.py
+++ b/src/config.py
@@ -8,6 +8,7 @@ from zoneinfo import ZoneInfo
 from dotenv import load_dotenv
 
 from src.family_config import load_family_config
+from src.integrations import INTEGRATION_REGISTRY, get_enabled_integrations, get_integration_status
 
 load_dotenv()
 
@@ -19,21 +20,6 @@ REQUIRED_VARS = [
     "WHATSAPP_APP_SECRET",
     "N8N_WEBHOOK_SECRET",
 ]
-
-OPTIONAL_GROUPS = {
-    "Notion": [
-        "NOTION_TOKEN",
-        "NOTION_ACTION_ITEMS_DB",
-        "NOTION_MEAL_PLANS_DB",
-        "NOTION_MEETINGS_DB",
-        "NOTION_FAMILY_PROFILE_PAGE",
-    ],
-    "Google Calendar": [
-        "GOOGLE_CALENDAR_FAMILY_ID",
-    ],
-    "YNAB": ["YNAB_ACCESS_TOKEN", "YNAB_BUDGET_ID"],
-    "Updates": ["ADMIN_PHONE", "UPSTREAM_REMOTE"],
-}
 
 logger = logging.getLogger(__name__)
 
@@ -49,26 +35,37 @@ def _load_env():
         print("Copy .env.example to .env and fill in all values.", file=sys.stderr)
         sys.exit(1)
 
-    # Log status of optional integration groups
-    # Some vars have legacy aliases — check either name
-    _LEGACY_FALLBACKS = {
-        "GOOGLE_CALENDAR_PARTNER1_ID": "GOOGLE_CALENDAR_JASON_ID",
-        "GOOGLE_CALENDAR_PARTNER2_ID": "GOOGLE_CALENDAR_ERIN_ID",
-        "PARTNER1_PHONE": "JASON_PHONE",
-        "PARTNER2_PHONE": "ERIN_PHONE",
-    }
+    # Log integration status using centralized registry
     enabled = []
-    for group, vars_ in OPTIONAL_GROUPS.items():
-        missing_optional = [v for v in vars_ if not (os.getenv(v) or os.getenv(_LEGACY_FALLBACKS.get(v, "")))]
-        if missing_optional:
-            logger.warning("%s integration not configured (missing: %s)", group, ", ".join(missing_optional))
+    disabled = []
+    for name, integration in INTEGRATION_REGISTRY.items():
+        if integration.always_enabled or integration.required:
+            continue
+        status = get_integration_status(name)
+        if status == "enabled":
+            enabled.append(integration.display_name)
+        elif status == "partial":
+            set_vars = [v for v in integration.env_vars if os.getenv(v)]
+            missing_vars = [v for v in integration.env_vars if not os.getenv(v)]
+            logger.warning(
+                "%s partially configured (%d/%d vars set, missing: %s)",
+                integration.display_name,
+                len(set_vars),
+                len(integration.env_vars),
+                ", ".join(missing_vars),
+            )
         else:
-            enabled.append(group)
+            disabled.append(integration.display_name)
     if enabled:
         logger.info("Enabled integrations: %s", ", ".join(enabled))
+    if disabled:
+        logger.info("Disabled integrations: %s", ", ".join(disabled))
 
 
 _load_env()
+
+# Compute enabled integrations once at startup
+ENABLED_INTEGRATIONS: set[str] = get_enabled_integrations()
 
 # Anthropic
 ANTHROPIC_API_KEY: str = os.environ.get("ANTHROPIC_API_KEY", "")

--- a/src/integrations.py
+++ b/src/integrations.py
@@ -1,0 +1,257 @@
+"""Centralized integration registry.
+
+Maps each integration to its env vars, tools, and prompt tags.
+Drives tool filtering, prompt filtering, health checks, and validation.
+"""
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class Integration:
+    """An external service integration."""
+
+    name: str
+    display_name: str
+    required: bool
+    env_vars: tuple[str, ...]
+    tools: tuple[str, ...]
+    prompt_tag: str
+    always_enabled: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Registry — single source of truth for all integrations
+# ---------------------------------------------------------------------------
+
+INTEGRATION_REGISTRY: dict[str, Integration] = {
+    "core": Integration(
+        name="core",
+        display_name="Core",
+        required=False,
+        env_vars=(),
+        tools=(
+            "get_daily_context",
+            "save_preference",
+            "list_preferences",
+            "remove_preference",
+            "get_drive_times",
+            "save_drive_time",
+            "delete_drive_time",
+            "save_routine",
+            "get_routine",
+            "delete_routine",
+            "get_help",
+        ),
+        prompt_tag="core",
+        always_enabled=True,
+    ),
+    "whatsapp": Integration(
+        name="whatsapp",
+        display_name="WhatsApp",
+        required=True,
+        env_vars=(
+            "WHATSAPP_PHONE_NUMBER_ID",
+            "WHATSAPP_ACCESS_TOKEN",
+            "WHATSAPP_VERIFY_TOKEN",
+            "WHATSAPP_APP_SECRET",
+        ),
+        tools=(),
+        prompt_tag="whatsapp",
+    ),
+    "ai_api": Integration(
+        name="ai_api",
+        display_name="Anthropic AI",
+        required=True,
+        env_vars=("ANTHROPIC_API_KEY",),
+        tools=(),
+        prompt_tag="ai_api",
+    ),
+    "notion": Integration(
+        name="notion",
+        display_name="Notion",
+        required=False,
+        env_vars=(
+            "NOTION_TOKEN",
+            "NOTION_ACTION_ITEMS_DB",
+            "NOTION_MEAL_PLANS_DB",
+            "NOTION_MEETINGS_DB",
+            "NOTION_FAMILY_PROFILE_PAGE",
+        ),
+        tools=(
+            "get_action_items",
+            "add_action_item",
+            "complete_action_item",
+            "add_topic",
+            "get_family_profile",
+            "update_family_profile",
+            "create_meeting",
+            "rollover_incomplete_items",
+            "save_meal_plan",
+            "get_meal_plan",
+            "get_backlog_items",
+            "add_backlog_item",
+            "complete_backlog_item",
+            "get_routine_templates",
+            "generate_meal_plan",
+            "handle_meal_swap",
+            "set_quiet_day",
+            "complete_chore",
+            "skip_chore",
+            "set_chore_preference",
+            "get_chore_history",
+            "check_reorder_items",
+            "confirm_groceries_ordered",
+            "start_laundry",
+            "advance_laundry",
+            "cancel_laundry",
+        ),
+        prompt_tag="notion",
+    ),
+    "google_calendar": Integration(
+        name="google_calendar",
+        display_name="Google Calendar",
+        required=False,
+        env_vars=("GOOGLE_CALENDAR_FAMILY_ID",),
+        tools=(
+            "get_calendar_events",
+            "write_calendar_blocks",
+            "create_quick_event",
+            "delete_calendar_event",
+            "list_recurring_events",
+        ),
+        prompt_tag="google_calendar",
+    ),
+    "outlook": Integration(
+        name="outlook",
+        display_name="Outlook Calendar",
+        required=False,
+        env_vars=("OUTLOOK_CALENDAR_ICS_URL",),
+        tools=("get_outlook_events",),
+        prompt_tag="outlook",
+    ),
+    "ynab": Integration(
+        name="ynab",
+        display_name="YNAB",
+        required=False,
+        env_vars=("YNAB_ACCESS_TOKEN", "YNAB_BUDGET_ID"),
+        tools=(
+            "get_budget_summary",
+            "search_transactions",
+            "recategorize_transaction",
+            "create_transaction",
+            "update_category_budget",
+            "move_money",
+            "budget_health_check",
+            "apply_goal_suggestion",
+            "allocate_bonus",
+            "approve_allocation",
+            "amazon_sync_status",
+            "amazon_sync_trigger",
+            "amazon_spending_breakdown",
+            "amazon_set_auto_split",
+            "amazon_undo_split",
+            "email_sync_trigger",
+            "email_sync_status",
+            "email_set_auto_categorize",
+            "email_undo_categorize",
+            "process_receipt",
+            "confirm_receipt_categorization",
+            "retry_receipt_match",
+            "split_receipt_transaction",
+        ),
+        prompt_tag="ynab",
+    ),
+    "anylist": Integration(
+        name="anylist",
+        display_name="AnyList",
+        required=False,
+        env_vars=("ANYLIST_SIDECAR_URL",),
+        tools=(
+            "push_grocery_list",
+            "get_grocery_history",
+            "get_staple_items",
+        ),
+        prompt_tag="anylist",
+    ),
+    "recipes": Integration(
+        name="recipes",
+        display_name="Recipes",
+        required=False,
+        env_vars=("NOTION_RECIPES_DB", "NOTION_COOKBOOKS_DB", "R2_ACCOUNT_ID"),
+        tools=(
+            "extract_and_save_recipe",
+            "search_recipes",
+            "get_recipe_details",
+            "recipe_to_grocery_list",
+            "list_cookbooks",
+            "search_downshiftology",
+            "get_downshiftology_details",
+            "import_downshiftology_recipe",
+        ),
+        prompt_tag="recipes",
+    ),
+}
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _check_env_vars(env_vars: tuple[str, ...]) -> str:
+    """Check env var status: 'enabled', 'disabled', or 'partial'."""
+    if not env_vars:
+        return "enabled"
+    set_vars = [v for v in env_vars if os.environ.get(v)]
+    if len(set_vars) == len(env_vars):
+        return "enabled"
+    if len(set_vars) == 0:
+        return "disabled"
+    return "partial"
+
+
+def get_enabled_integrations() -> set[str]:
+    """Return set of integration names that are fully configured.
+
+    An integration is enabled if:
+    - It is always_enabled (core), OR
+    - All of its env_vars are set in the environment
+    """
+    enabled = set()
+    for name, integration in INTEGRATION_REGISTRY.items():
+        if integration.always_enabled:
+            enabled.add(name)
+        elif _check_env_vars(integration.env_vars) == "enabled":
+            enabled.add(name)
+    return enabled
+
+
+def get_tools_for_integrations(enabled: set[str]) -> list[str]:
+    """Return flat list of tool names for enabled integrations."""
+    tools = []
+    for name in enabled:
+        if name in INTEGRATION_REGISTRY:
+            tools.extend(INTEGRATION_REGISTRY[name].tools)
+    return tools
+
+
+def is_integration_enabled(name: str) -> bool:
+    """Check if a specific integration is enabled."""
+    integration = INTEGRATION_REGISTRY.get(name)
+    if not integration:
+        return False
+    if integration.always_enabled:
+        return True
+    return _check_env_vars(integration.env_vars) == "enabled"
+
+
+def get_integration_status(name: str) -> str:
+    """Return status of an integration: 'enabled', 'disabled', or 'partial'."""
+    integration = INTEGRATION_REGISTRY.get(name)
+    if not integration:
+        return "disabled"
+    if integration.always_enabled:
+        return "enabled"
+    return _check_env_vars(integration.env_vars)

--- a/src/prompts/__init__.py
+++ b/src/prompts/__init__.py
@@ -13,12 +13,55 @@ TOOLS_DIR = PROMPTS_DIR / "tools"
 TEMPLATES_DIR = PROMPTS_DIR / "templates"
 
 
-@lru_cache(maxsize=1)
-def load_system_prompt() -> str:
-    """Load and concatenate all system prompt section files in sorted filename order.
+def _parse_frontmatter(content: str) -> tuple[dict, str]:
+    """Parse YAML frontmatter from markdown content.
+
+    Returns (metadata_dict, content_without_frontmatter).
+    If no frontmatter found, returns ({}, content).
+    """
+    if not content.startswith("---"):
+        return {}, content
+    end = content.find("---", 3)
+    if end == -1:
+        return {}, content
+    frontmatter_text = content[3:end].strip()
+    metadata: dict = {}
+    for line in frontmatter_text.splitlines():
+        if ":" in line:
+            key, value = line.split(":", 1)
+            key = key.strip()
+            value = value.strip()
+            if value.startswith("[") and value.endswith("]"):
+                metadata[key] = [v.strip() for v in value[1:-1].split(",")]
+            else:
+                metadata[key] = value
+    body = content[end + 3 :].strip()
+    return metadata, body
+
+
+def _should_include_section(metadata: dict, enabled: set[str]) -> bool:
+    """Check if a prompt section should be included based on enabled integrations."""
+    requires = metadata.get("requires")
+    requires_any = metadata.get("requires_any")
+    if requires:
+        return all(tag in enabled for tag in requires)
+    if requires_any:
+        return any(tag in enabled for tag in requires_any)
+    # No frontmatter requirements → always include
+    return True
+
+
+@lru_cache(maxsize=4)
+def load_system_prompt(enabled_integrations: frozenset[str] | None = None) -> str:
+    """Load and concatenate system prompt sections, filtered by enabled integrations.
 
     Files in src/prompts/system/ are numbered (01-identity.md, 02-response-rules.md, etc.)
-    and joined with double newlines to form the complete system prompt.
+    and joined with double newlines. YAML frontmatter tags (requires/requires_any)
+    control which sections are included based on configured integrations.
+
+    Args:
+        enabled_integrations: Frozenset of enabled integration names. If None, all
+            sections are included (backward compatible).
 
     Raises FileNotFoundError if the system directory is empty or missing.
     """
@@ -27,18 +70,23 @@ def load_system_prompt() -> str:
         raise FileNotFoundError(
             f"No system prompt files found in {SYSTEM_DIR}. Expected numbered .md files (e.g., 01-identity.md)."
         )
+    enabled = set(enabled_integrations) if enabled_integrations is not None else None
     sections = []
     for f in files:
-        content = f.read_text(encoding="utf-8").strip()
-        if not content:
+        raw = f.read_text(encoding="utf-8").strip()
+        if not raw:
             logger.warning("Empty system prompt section: %s", f.name)
+            continue
+        metadata, content = _parse_frontmatter(raw)
+        if enabled is not None and not _should_include_section(metadata, enabled):
+            logger.debug("Skipping prompt section %s (integration not enabled)", f.name)
             continue
         sections.append(content)
     return "\n\n".join(sections)
 
 
-@lru_cache(maxsize=1)
-def load_tool_descriptions() -> dict[str, str]:
+@lru_cache(maxsize=4)
+def load_tool_descriptions(enabled_tools: frozenset[str] | None = None) -> dict[str, str]:
     """Parse tool description files into a dict mapping tool_name -> description.
 
     Each file in src/prompts/tools/ uses ## headers to delimit individual tool descriptions:
@@ -49,10 +97,15 @@ def load_tool_descriptions() -> dict[str, str]:
         ## get_outlook_events
         Returns Jason's work calendar events...
 
+    Args:
+        enabled_tools: Frozenset of tool names to include. If None, all tools
+            are included (backward compatible).
+
     Returns a dict like {"get_calendar_events": "Fetch upcoming...", ...}.
     Logs warnings for files with no parseable headers.
     """
     descriptions: dict[str, str] = {}
+    allowed = set(enabled_tools) if enabled_tools is not None else None
     files = sorted(TOOLS_DIR.glob("*.md"))
     if not files:
         logger.warning("No tool description files found in %s", TOOLS_DIR)
@@ -66,7 +119,7 @@ def load_tool_descriptions() -> dict[str, str]:
         for line in content.splitlines():
             if line.startswith("## "):
                 # Save previous tool
-                if current_tool:
+                if current_tool and (allowed is None or current_tool in allowed):
                     descriptions[current_tool] = "\n".join(current_lines).strip()
                 current_tool = line[3:].strip()
                 current_lines = []
@@ -74,7 +127,7 @@ def load_tool_descriptions() -> dict[str, str]:
                 current_lines.append(line)
 
         # Save last tool in file
-        if current_tool:
+        if current_tool and (allowed is None or current_tool in allowed):
             descriptions[current_tool] = "\n".join(current_lines).strip()
 
     logger.info("Loaded %d tool descriptions from %d files", len(descriptions), len(files))
@@ -107,20 +160,30 @@ class _PassthroughDict(defaultdict):
         return "{" + key + "}"
 
 
-def render_system_prompt(family_config: dict) -> str:
+def render_system_prompt(family_config: dict, enabled_integrations: frozenset[str] | None = None) -> str:
     """Load system prompt template and substitute family config placeholders.
 
     Uses format_map with a passthrough dict so unknown {placeholders} (e.g., from
     template files) pass through unchanged.
+
+    Args:
+        family_config: Family config placeholder dict.
+        enabled_integrations: Frozenset of enabled integration names for filtering.
+            If None, all sections are included.
     """
-    template = load_system_prompt()
+    template = load_system_prompt(enabled_integrations=enabled_integrations)
     mapping = _PassthroughDict(str, family_config)
     return template.format_map(mapping)
 
 
-def render_tool_descriptions(family_config: dict) -> dict[str, str]:
-    """Load tool descriptions and substitute family config placeholders in each."""
-    raw = load_tool_descriptions()
+def render_tool_descriptions(family_config: dict, enabled_tools: frozenset[str] | None = None) -> dict[str, str]:
+    """Load tool descriptions and substitute family config placeholders in each.
+
+    Args:
+        family_config: Family config placeholder dict.
+        enabled_tools: Frozenset of tool names to include. If None, all tools included.
+    """
+    raw = load_tool_descriptions(enabled_tools=enabled_tools)
     mapping = _PassthroughDict(str, family_config)
     return {name: desc.format_map(mapping) for name, desc in raw.items()}
 

--- a/src/prompts/system/01-identity.md
+++ b/src/prompts/system/01-identity.md
@@ -1,3 +1,6 @@
+---
+requires: [core]
+---
 You are {bot_name} — the family assistant for {partner1_name} and {partner2_name}'s family. You live in their WhatsApp group chat and help plan, run, and follow up on weekly family meetings. You also generate daily plans for {partner2_name} and manage their household coordination. {partner2_name} named you "{bot_name}" — lean into that identity when chatting (friendly, organized, slightly playful).
 
 **Family:**

--- a/src/prompts/system/02-response-rules.md
+++ b/src/prompts/system/02-response-rules.md
@@ -1,3 +1,6 @@
+---
+requires: [core]
+---
 **Your rules:**
 1. ALWAYS format responses as structured checklists with WhatsApp formatting:
    - Use *bold* for section headers

--- a/src/prompts/system/03-daily-planner.md
+++ b/src/prompts/system/03-daily-planner.md
@@ -1,3 +1,6 @@
+---
+requires_any: [notion, google_calendar, outlook]
+---
 **Daily planner rules** (when asked "what's my day look like?" or triggered by the morning briefing):
 9. Call get_daily_context at the start of any planning, scheduling, daily plan, or recommendation interaction. This returns today's calendar events grouped by person, childcare status (who has {child2_name}), communication mode, active preferences, and pending backlog count. Do NOT call for simple factual questions.
 **Calendar-aware planning (CRITICAL — GitHub issue #21):**

--- a/src/prompts/system/04-grocery-recipes.md
+++ b/src/prompts/system/04-grocery-recipes.md
@@ -1,3 +1,6 @@
+---
+requires_any: [anylist, recipes]
+---
 **Grocery integration:**
 18. After generating a meal plan, offer: "Want me to push this to AnyList for delivery?" If the user says yes or "order groceries", push the grocery list to AnyList via push_grocery_list. If the AnyList sidecar is unavailable, send a well-formatted list organized by store section (Produce, Meat, Dairy, Pantry, Frozen, Bakery, Beverages) as a fallback.
 

--- a/src/prompts/system/05-chores-nudges.md
+++ b/src/prompts/system/05-chores-nudges.md
@@ -1,3 +1,6 @@
+---
+requires: [notion]
+---
 **Nudge interactions (tone: warm, encouraging, zero guilt):**
 23. You send proactive departure reminders before {partner2_name}'s calendar events. If {partner2_name} says "snooze" or "remind me in 10", snooze the most recent departure nudge (creates a new reminder in 10 minutes). If she says "stop", "dismiss", or "I know", dismiss the nudge (no more reminders for that event).
 24. If {partner2_name} says "quiet day", "no nudges today", or "leave me alone today", call set_quiet_day to suppress all proactive nudges for the rest of the day. She can still message you and get responses — only proactive nudges stop.

--- a/src/prompts/system/06-budget.md
+++ b/src/prompts/system/06-budget.md
@@ -1,3 +1,6 @@
+---
+requires: [ynab]
+---
 **Budget management:**
 32. For transaction searches ("what did we spend at Costco?"), use search_transactions with the payee name. Show amounts as dollars, sorted by most recent. Default search is current month.
 33. For recategorization ("categorize the Target charge as Home Supplies"), use recategorize_transaction. If multiple matches, show the list and ask which one. Always confirm the change.

--- a/src/prompts/system/07-calendar-reminders.md
+++ b/src/prompts/system/07-calendar-reminders.md
@@ -1,3 +1,6 @@
+---
+requires: [google_calendar]
+---
 **Quick reminders & events:**
 37. When someone says "remind me to...", "remind {partner1_name} to...", "pick up X at Y time", "don't forget to...", or mentions any time-specific task, use create_quick_event to add it to the shared family calendar. Format the summary as "Sender → Assignee: task" (e.g., "{partner2_name} → {partner1_name}: pick up dog"). If it's a self-reminder, use just "{partner2_name}: dentist appointment". Include the original message as the event description for context. The event goes on the shared family calendar so both partners can see it. Use the date and time shown at the top of this prompt if not specified. Default to a 15-minute popup reminder.
 

--- a/src/prompts/system/08-advanced.md
+++ b/src/prompts/system/08-advanced.md
@@ -1,3 +1,6 @@
+---
+requires_any: [notion, google_calendar, ynab]
+---
 **Daily briefing cross-domain:**
 47. When generating the daily plan, also check: budget health (any categories significantly over?), tonight's meal plan (is it appropriate for today's schedule density?), overdue action items (is there a free block to tackle one?), and pending grocery orders. Weave these into the briefing naturally — don't add separate sections. Keep it concise for WhatsApp.
 48. After sending the daily briefing, {partner2_name} may reply with adjustments ("move chiro to Thursday", "swap tonight's dinner", "I don't want to do that chore today"). Use existing tools (create_quick_event, handle_meal_swap, skip_chore) to act on these requests. Conversation memory means you remember what you suggested in the briefing.

--- a/src/prompts/system/09-forward-to-calendar.md
+++ b/src/prompts/system/09-forward-to-calendar.md
@@ -1,3 +1,6 @@
+---
+requires: [google_calendar]
+---
 **Forward-to-calendar — auto-detect appointments in messages:**
 44. When a message contains appointment-like language — confirmed, scheduled, reservation, appointment, booked — along with a date and time, proactively offer to create a calendar event. This applies to both text messages and photos/screenshots of confirmations. Do NOT auto-create the event. Instead:
     a. Extract: event title/description, date, start time, end time (if present), and location (if present).

--- a/src/prompts/system/10-receipt-categorization.md
+++ b/src/prompts/system/10-receipt-categorization.md
@@ -1,3 +1,6 @@
+---
+requires: [ynab]
+---
 ### Receipt Photo → YNAB Categorization
 
 49. **Receipt detection**: When a user sends a photo that appears to be a receipt (store receipt, checkout summary, purchase confirmation, credit card slip), automatically call `process_receipt` to extract the data and match it to a YNAB transaction. Do NOT force receipt extraction on non-receipt images (food photos, screenshots of texts, memes, etc.).

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,145 @@
+"""Tests for the integration registry (src/integrations.py)."""
+
+import os
+from unittest.mock import patch
+
+from src.integrations import (
+    INTEGRATION_REGISTRY,
+    get_enabled_integrations,
+    get_integration_status,
+    get_tools_for_integrations,
+    is_integration_enabled,
+)
+
+
+class TestIntegrationRegistry:
+    """Test INTEGRATION_REGISTRY structure and completeness."""
+
+    def test_all_integrations_have_required_fields(self):
+        for name, integration in INTEGRATION_REGISTRY.items():
+            assert integration.name == name, f"{name}: name mismatch"
+            assert integration.display_name, f"{name}: missing display_name"
+            assert isinstance(integration.required, bool), f"{name}: required must be bool"
+            assert isinstance(integration.env_vars, tuple), f"{name}: env_vars must be tuple"
+            assert isinstance(integration.tools, tuple), f"{name}: tools must be tuple"
+            assert integration.prompt_tag, f"{name}: missing prompt_tag"
+
+    def test_core_is_always_enabled(self):
+        core = INTEGRATION_REGISTRY["core"]
+        assert core.always_enabled is True
+        assert len(core.env_vars) == 0
+
+    def test_required_integrations(self):
+        required = {n for n, i in INTEGRATION_REGISTRY.items() if i.required}
+        assert "whatsapp" in required
+        assert "ai_api" in required
+        assert "notion" not in required
+
+    def test_no_duplicate_tools_across_integrations(self):
+        seen = {}
+        for name, integration in INTEGRATION_REGISTRY.items():
+            for tool in integration.tools:
+                assert tool not in seen, f"Tool '{tool}' in both '{seen[tool]}' and '{name}'"
+                seen[tool] = name
+
+
+class TestGetEnabledIntegrations:
+    """Test get_enabled_integrations() with various env configurations."""
+
+    def test_minimal_config(self):
+        """Only required vars set — core + whatsapp + ai_api should be enabled."""
+        minimal_env = {
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "WHATSAPP_PHONE_NUMBER_ID": "123",
+            "WHATSAPP_ACCESS_TOKEN": "token",
+            "WHATSAPP_VERIFY_TOKEN": "verify",
+            "WHATSAPP_APP_SECRET": "secret",
+        }
+        with patch.dict(os.environ, minimal_env, clear=True):
+            enabled = get_enabled_integrations()
+        assert "core" in enabled
+        assert "whatsapp" in enabled
+        assert "ai_api" in enabled
+        assert "notion" not in enabled
+        assert "google_calendar" not in enabled
+        assert "ynab" not in enabled
+
+    def test_full_config(self):
+        """All env vars set — all integrations enabled."""
+        full_env = {
+            "ANTHROPIC_API_KEY": "sk-ant-test",
+            "WHATSAPP_PHONE_NUMBER_ID": "123",
+            "WHATSAPP_ACCESS_TOKEN": "token",
+            "WHATSAPP_VERIFY_TOKEN": "verify",
+            "WHATSAPP_APP_SECRET": "secret",
+            "NOTION_TOKEN": "ntn_test",
+            "NOTION_ACTION_ITEMS_DB": "db1",
+            "NOTION_MEAL_PLANS_DB": "db2",
+            "NOTION_MEETINGS_DB": "db3",
+            "NOTION_FAMILY_PROFILE_PAGE": "page1",
+            "GOOGLE_CALENDAR_FAMILY_ID": "cal@group",
+            "OUTLOOK_CALENDAR_ICS_URL": "https://outlook.example.com",
+            "YNAB_ACCESS_TOKEN": "ynab_token",
+            "YNAB_BUDGET_ID": "budget_id",
+            "ANYLIST_SIDECAR_URL": "http://localhost:3000",
+            "NOTION_RECIPES_DB": "rdb1",
+            "NOTION_COOKBOOKS_DB": "rdb2",
+            "R2_ACCOUNT_ID": "r2_id",
+        }
+        with patch.dict(os.environ, full_env, clear=True):
+            enabled = get_enabled_integrations()
+        assert "notion" in enabled
+        assert "google_calendar" in enabled
+        assert "ynab" in enabled
+        assert "anylist" in enabled
+        assert "recipes" in enabled
+
+    def test_partial_notion_not_enabled(self):
+        """Partial Notion config — should not be enabled."""
+        partial_env = {
+            "NOTION_TOKEN": "ntn_test",
+            "NOTION_ACTION_ITEMS_DB": "db1",
+            # Missing: NOTION_MEAL_PLANS_DB, NOTION_MEETINGS_DB, NOTION_FAMILY_PROFILE_PAGE
+        }
+        with patch.dict(os.environ, partial_env, clear=True):
+            enabled = get_enabled_integrations()
+        assert "notion" not in enabled
+
+
+class TestGetToolsForIntegrations:
+    """Test get_tools_for_integrations()."""
+
+    def test_core_only(self):
+        tools = get_tools_for_integrations({"core"})
+        assert "get_daily_context" in tools
+        assert "save_preference" in tools
+        assert "get_help" in tools
+        assert "get_action_items" not in tools
+
+    def test_core_plus_notion(self):
+        tools = get_tools_for_integrations({"core", "notion"})
+        assert "get_daily_context" in tools
+        assert "get_action_items" in tools
+        assert "get_budget_summary" not in tools
+
+    def test_empty_returns_nothing(self):
+        tools = get_tools_for_integrations(set())
+        assert len(tools) == 0
+
+
+class TestIntegrationStatus:
+    """Test get_integration_status() and is_integration_enabled()."""
+
+    def test_core_always_enabled(self):
+        assert is_integration_enabled("core") is True
+        assert get_integration_status("core") == "enabled"
+
+    def test_unknown_integration(self):
+        assert is_integration_enabled("nonexistent") is False
+        assert get_integration_status("nonexistent") == "disabled"
+
+    def test_partial_status(self):
+        partial_env = {"NOTION_TOKEN": "test"}
+        with patch.dict(os.environ, partial_env, clear=True):
+            assert get_integration_status("notion") == "partial"
+            assert is_integration_enabled("notion") is False

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -2,7 +2,14 @@
 
 import pytest
 
-from src.prompts import load_system_prompt, load_tool_descriptions, render_system_prompt, render_template
+from src.prompts import (
+    _parse_frontmatter,
+    _should_include_section,
+    load_system_prompt,
+    load_tool_descriptions,
+    render_system_prompt,
+    render_template,
+)
 
 
 def test_load_system_prompt_returns_nonempty():
@@ -61,3 +68,81 @@ def test_render_template_missing_placeholder():
     """render_template raises KeyError when a required placeholder is missing."""
     with pytest.raises(KeyError):
         render_template("amazon_order_parsing")  # missing clean_text
+
+
+class TestParseFrontmatter:
+    """Test _parse_frontmatter() helper."""
+
+    def test_no_frontmatter(self):
+        metadata, body = _parse_frontmatter("# Just a heading\nSome content")
+        assert metadata == {}
+        assert body == "# Just a heading\nSome content"
+
+    def test_requires_tag(self):
+        content = "---\nrequires: [core]\n---\n# Identity\nYou are a bot."
+        metadata, body = _parse_frontmatter(content)
+        assert metadata["requires"] == ["core"]
+        assert body == "# Identity\nYou are a bot."
+
+    def test_requires_any_tag(self):
+        content = "---\nrequires_any: [notion, google_calendar, outlook]\n---\nContent"
+        metadata, body = _parse_frontmatter(content)
+        assert metadata["requires_any"] == ["notion", "google_calendar", "outlook"]
+
+    def test_malformed_no_closing(self):
+        content = "---\nrequires: [core]\nNo closing delimiter"
+        metadata, body = _parse_frontmatter(content)
+        assert metadata == {}  # No closing --- → treated as no frontmatter
+
+
+class TestShouldIncludeSection:
+    """Test _should_include_section() filtering logic."""
+
+    def test_no_metadata_always_included(self):
+        assert _should_include_section({}, {"core"}) is True
+
+    def test_requires_all_present(self):
+        assert _should_include_section({"requires": ["core"]}, {"core", "notion"}) is True
+
+    def test_requires_missing(self):
+        assert _should_include_section({"requires": ["notion"]}, {"core"}) is False
+
+    def test_requires_any_one_present(self):
+        meta = {"requires_any": ["notion", "google_calendar"]}
+        assert _should_include_section(meta, {"core", "notion"}) is True
+
+    def test_requires_any_none_present(self):
+        meta = {"requires_any": ["notion", "google_calendar"]}
+        assert _should_include_section(meta, {"core"}) is False
+
+
+class TestFilteredSystemPrompt:
+    """Test load_system_prompt() with integration filtering."""
+
+    def test_core_only_excludes_budget(self):
+        """With only core enabled, budget section should be excluded."""
+        full = load_system_prompt()
+        core_only = load_system_prompt(enabled_integrations=frozenset({"core"}))
+        assert len(core_only) < len(full)
+
+    def test_all_integrations_matches_unfiltered(self):
+        """With all integrations enabled, output should match unfiltered."""
+        all_integrations = frozenset(
+            {"core", "whatsapp", "ai_api", "notion", "google_calendar", "outlook", "ynab", "anylist", "recipes"}
+        )
+        filtered = load_system_prompt(enabled_integrations=all_integrations)
+        unfiltered = load_system_prompt()
+        assert filtered == unfiltered
+
+
+class TestFilteredToolDescriptions:
+    """Test load_tool_descriptions() with tool filtering."""
+
+    def test_filter_to_subset(self):
+        subset = frozenset({"get_daily_context", "save_preference"})
+        descs = load_tool_descriptions(enabled_tools=subset)
+        assert set(descs.keys()) == subset
+
+    def test_none_returns_all(self):
+        descs = load_tool_descriptions()
+        assert len(descs) == 77

--- a/tests/test_validate_setup.py
+++ b/tests/test_validate_setup.py
@@ -1,0 +1,207 @@
+"""Tests for the validation script (scripts/validate_setup.py)."""
+
+import sys
+from pathlib import Path
+
+# Add project root so we can import the validation module
+sys.path.insert(0, str(Path(__file__).parent.parent))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+from scripts.validate_setup import validate_env, validate_family_config, validate_integrations
+
+
+class TestValidateFamilyConfig:
+    """Test validate_family_config()."""
+
+    def test_missing_file(self, tmp_path, capsys):
+        errors, warnings, config = validate_family_config(str(tmp_path / "nonexistent.yaml"))
+        assert len(errors) == 1
+        assert "not found" in errors[0].lower()
+
+    def test_valid_config(self, tmp_path, capsys):
+        config_file = tmp_path / "family.yaml"
+        config_file.write_text(
+            """
+family:
+  name: The Smiths
+  timezone: America/New_York
+  partners:
+    - name: Alice
+    - name: Bob
+bot:
+  name: FamilyBot
+"""
+        )
+        errors, warnings, config = validate_family_config(str(config_file))
+        assert len(errors) == 0
+        assert config["family"]["name"] == "The Smiths"
+
+    def test_missing_family_name(self, tmp_path, capsys):
+        config_file = tmp_path / "family.yaml"
+        config_file.write_text(
+            """
+bot:
+  name: TestBot
+"""
+        )
+        errors, warnings, config = validate_family_config(str(config_file))
+        assert any("family name" in e.lower() for e in errors)
+
+    def test_missing_bot_name(self, tmp_path, capsys):
+        config_file = tmp_path / "family.yaml"
+        config_file.write_text(
+            """
+family:
+  name: TestFamily
+  partners:
+    - name: Alice
+"""
+        )
+        errors, warnings, config = validate_family_config(str(config_file))
+        assert any("bot name" in e.lower() for e in errors)
+
+    def test_invalid_timezone(self, tmp_path, capsys):
+        config_file = tmp_path / "family.yaml"
+        config_file.write_text(
+            """
+family:
+  name: TestFamily
+  timezone: Invalid/Timezone
+  partners:
+    - name: Alice
+bot:
+  name: TestBot
+"""
+        )
+        errors, warnings, config = validate_family_config(str(config_file))
+        assert any("timezone" in e.lower() for e in errors)
+
+    def test_no_timezone_warns(self, tmp_path, capsys):
+        config_file = tmp_path / "family.yaml"
+        config_file.write_text(
+            """
+family:
+  name: TestFamily
+  partners:
+    - name: Alice
+bot:
+  name: TestBot
+"""
+        )
+        errors, warnings, config = validate_family_config(str(config_file))
+        assert len(errors) == 0
+        assert any("timezone" in w.lower() for w in warnings)
+
+    def test_invalid_yaml(self, tmp_path, capsys):
+        config_file = tmp_path / "family.yaml"
+        config_file.write_text("{{invalid yaml: [")
+        errors, warnings, config = validate_family_config(str(config_file))
+        assert any("parse" in e.lower() or "yaml" in e.lower() for e in errors)
+
+
+class TestValidateEnv:
+    """Test validate_env()."""
+
+    def test_missing_file(self, tmp_path, capsys):
+        errors, warnings, env_vars = validate_env(str(tmp_path / ".env"))
+        assert len(errors) == 1
+        assert "not found" in errors[0].lower()
+
+    def test_valid_env(self, tmp_path, capsys):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            """
+ANTHROPIC_API_KEY=sk-ant-test-key-12345
+WHATSAPP_PHONE_NUMBER_ID=123456789
+WHATSAPP_ACCESS_TOKEN=token123
+WHATSAPP_VERIFY_TOKEN=verify123
+WHATSAPP_APP_SECRET=secret123
+N8N_WEBHOOK_SECRET=webhook123
+"""
+        )
+        errors, warnings, env_vars = validate_env(str(env_file))
+        assert len(errors) == 0
+        assert env_vars["ANTHROPIC_API_KEY"] == "sk-ant-test-key-12345"
+
+    def test_missing_required_vars(self, tmp_path, capsys):
+        env_file = tmp_path / ".env"
+        env_file.write_text("SOME_OTHER_VAR=value\n")
+        errors, warnings, env_vars = validate_env(str(env_file))
+        # Should have errors for all 6 required vars
+        assert len(errors) >= 5
+
+    def test_bad_api_key_prefix(self, tmp_path, capsys):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            """
+ANTHROPIC_API_KEY=bad-prefix-key
+WHATSAPP_PHONE_NUMBER_ID=123
+WHATSAPP_ACCESS_TOKEN=token
+WHATSAPP_VERIFY_TOKEN=verify
+WHATSAPP_APP_SECRET=secret
+N8N_WEBHOOK_SECRET=webhook
+"""
+        )
+        errors, warnings, env_vars = validate_env(str(env_file))
+        assert any("ANTHROPIC_API_KEY" in w and "prefix" in w for w in warnings)
+
+    def test_invalid_phone_number(self, tmp_path, capsys):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            """
+ANTHROPIC_API_KEY=sk-ant-test
+WHATSAPP_PHONE_NUMBER_ID=123
+WHATSAPP_ACCESS_TOKEN=token
+WHATSAPP_VERIFY_TOKEN=verify
+WHATSAPP_APP_SECRET=secret
+N8N_WEBHOOK_SECRET=webhook
+PARTNER1_PHONE=+1-555-1234
+"""
+        )
+        errors, warnings, env_vars = validate_env(str(env_file))
+        assert any("format" in w.lower() and "phone" in w.lower() for w in warnings)
+
+    def test_valid_phone_number(self, tmp_path, capsys):
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            """
+ANTHROPIC_API_KEY=sk-ant-test
+WHATSAPP_PHONE_NUMBER_ID=123
+WHATSAPP_ACCESS_TOKEN=token
+WHATSAPP_VERIFY_TOKEN=verify
+WHATSAPP_APP_SECRET=secret
+N8N_WEBHOOK_SECRET=webhook
+PARTNER1_PHONE=15551234567
+PARTNER2_PHONE=15559876543
+"""
+        )
+        errors, warnings, env_vars = validate_env(str(env_file))
+        # No phone-related warnings when both are valid
+        assert not any("phone" in w.lower() for w in warnings)
+
+
+class TestValidateIntegrations:
+    """Test validate_integrations()."""
+
+    def test_no_optional_integrations(self, capsys):
+        env_vars = {}
+        errors, warnings, enabled, disabled, avail, total = validate_integrations(env_vars)
+        assert enabled == 0
+        assert disabled > 0
+
+    def test_partial_integration_warns(self, capsys):
+        env_vars = {"NOTION_TOKEN": "test_token"}
+        errors, warnings, enabled, disabled, avail, total = validate_integrations(env_vars)
+        assert any("partially" in w.lower() for w in warnings)
+
+    def test_full_notion_integration(self, capsys):
+        env_vars = {
+            "NOTION_TOKEN": "ntn_test",
+            "NOTION_ACTION_ITEMS_DB": "db1",
+            "NOTION_MEAL_PLANS_DB": "db2",
+            "NOTION_MEETINGS_DB": "db3",
+            "NOTION_FAMILY_PROFILE_PAGE": "page1",
+        }
+        errors, warnings, enabled, disabled, avail, total = validate_integrations(env_vars)
+        assert enabled >= 1
+        assert total > 0


### PR DESCRIPTION
## Summary
- Add centralized integration registry (`src/integrations.py`) mapping 9 integrations → env vars, 77 tools, and prompt tags
- Dynamic tool and system prompt filtering at startup based on configured integrations — minimal deployments (WhatsApp + AI only) exclude unconfigured features
- YAML frontmatter on system prompt files (`requires`/`requires_any` tags) controls section inclusion
- Pre-deployment validation script (`scripts/validate_setup.py`) checks family.yaml + .env completeness
- Health endpoint uses registry for integration detection (fixes AnyList always-configured bug)
- Quick Start section in ONBOARDING.md, integration registry docs in CLAUDE.md
- 42 new tests across 3 test files (60 total passing)

## Test plan
- [ ] All 60 tests pass (`pytest tests/`)
- [ ] Lint + format clean (`ruff check src/` + `ruff format --check src/`)
- [ ] Validation script runs successfully against real config
- [ ] CI pipeline passes (lint, test, security scan)
- [ ] Live deploy: verify health endpoint returns healthy
- [ ] Live deploy: send WhatsApp message and get response
- [ ] Verify tool filtering: minimal env → only core tools loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)