### PR TITLE
fix: trigger fallback for non-retryable write tool failures

### DIFF
--- a/src/tool_resilience.py
+++ b/src/tool_resilience.py
@@ -161,6 +161,9 @@ def execute_with_retry(
 
             if category == ExceptionCategory.NON_RETRYABLE:
                 logger.warning("Tool %s non-retryable error: %s", tool_name, exc)
+                # Try fallback for write tools before returning error
+                if tool_name in FALLBACK_MAPPINGS:
+                    return _handle_exhausted_retries(tool_name, tool_input, exc)
                 return format_error_message(tool_name, exc, category)
 
             # RETRYABLE — retry if attempts remain

--- a/tests/test_tool_resilience.py
+++ b/tests/test_tool_resilience.py
@@ -162,10 +162,21 @@ class TestExecuteWithRetry:
     def test_non_retryable_no_retry(self):
         response = httpx.Response(403, request=httpx.Request("GET", "https://example.com"))
         func = MagicMock(side_effect=httpx.HTTPStatusError("forbidden", request=response.request, response=response))
-        result = execute_with_retry(func, "create_quick_event", {"title": "test"})
+        # Use a tool without fallback mapping to test pure non-retryable behavior
+        result = execute_with_retry(func, "get_calendar_events", {"date": "today"})
         assert func.call_count == 1
         assert "TOOL FAILED" in result
         assert "Google Calendar" in result
+
+    def test_non_retryable_write_tool_tries_fallback(self):
+        """Non-retryable error on a write tool should attempt fallback."""
+        response = httpx.Response(403, request=httpx.Request("GET", "https://example.com"))
+        func = MagicMock(side_effect=httpx.HTTPStatusError("forbidden", request=response.request, response=response))
+        fallback_result = (True, "FALLBACK USED: test", "add_action_item")
+        with patch("src.tool_resilience.attempt_fallback", return_value=fallback_result):
+            result = execute_with_retry(func, "create_quick_event", {"title": "test"})
+        assert func.call_count == 1  # No retry for non-retryable
+        assert "FALLBACK" in result
 
     def test_input_error_no_retry(self):
         func = MagicMock(side_effect=ValueError("bad date"))


### PR DESCRIPTION
## Summary
- Non-retryable errors on write tools (e.g., expired Google Calendar token) now attempt fallback before returning error
- Found during live E2E testing: `create_quick_event` failed with `invalid_grant` but skipped the Calendar→Notion fallback
- Also adds test for non-retryable write tool fallback behavior

## Test plan
- [x] 96/96 tests pass (1 new test added)
- [x] Lint clean
- [ ] E2E: resend calendar reminder, verify Notion action item is created as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)