### PR TITLE
fix: add PYTHONUNBUFFERED=1 to Dockerfile for Railway log visibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM python:3.12-slim
 
+ENV PYTHONUNBUFFERED=1
+
 WORKDIR /app
 
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
## Summary
- Add `ENV PYTHONUNBUFFERED=1` to Dockerfile so Python flushes stdout/stderr immediately
- Fixes missing logs from async background tasks (webhook processing, tool resilience, fallback chains)
- Railway's Nixpacks sets this automatically, but our custom Dockerfile build bypasses Nixpacks

## Test plan
- [ ] Deploy and send a test WhatsApp message
- [ ] Verify `railway logs --since 5m` shows processing logs (tool calls, resilience decisions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)