### PR TITLE
fix: robust logging setup for Railway/Axiom visibility

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -221,7 +221,9 @@ async def receive_message(request: Request, background_tasks: BackgroundTasks):
     if phone not in PHONE_TO_NAME:
         logger.warning(
             "Message from unrecognized number: %s (%s) — known phones: %s",
-            phone, sender_name, list(PHONE_TO_NAME.keys()),
+            phone,
+            sender_name,
+            list(PHONE_TO_NAME.keys()),
         )
         return {"status": "ok"}
 


### PR DESCRIPTION
## Summary
- Replace `logging.basicConfig()` with explicit root handler setup that uvicorn can't override
- Add diagnostic logs at webhook parse stage to identify why app-level logs weren't appearing
- Logs phone number + known phones on unrecognized number rejection for debugging

## Context
Axiom/Locomotive is working (captures uvicorn access logs) but Python application logs from
webhook processing were invisible. This suggests uvicorn's logging config was shadowing our
`basicConfig()` handler.

## Test plan
- [ ] Deploy and send a test WhatsApp webhook message
- [ ] Verify Axiom shows application-level logs (not just uvicorn access log)

🤖 Generated with [Claude Code](https://claude.com/claude-code)