### PR TITLE
fix: correct Axiom APL field names

### DIFF
--- a/src/log_diagnostics.py
+++ b/src/log_diagnostics.py
@@ -50,7 +50,8 @@ def _query_axiom(apl: str) -> list[dict[str, Any]]:
 
 def query_recent_errors(minutes: int = 5, limit: int = 20) -> list[dict[str, Any]]:
     """Query recent error-level logs from the last N minutes."""
-    apl = f"['{AXIOM_DATASET}'] | where data.severity == \"error\" | order by _time desc | limit {limit}"
+    # APL field names are top-level (severity, message) — NOT data.severity
+    apl = f"['{AXIOM_DATASET}'] | where severity == 'error' | order by _time desc | limit {limit}"
     return _query_axiom(apl)
 
 


### PR DESCRIPTION
## Summary
- Axiom APL queries use top-level column names (`severity`, `message`) not the nested `data.severity` paths from the JSON response format
- This caused a 400 error when the bot tried to self-diagnose tool failures

## Test plan
- [x] Verified correct APL query returns results against live Axiom dataset
- [x] All 36 tool_resilience tests pass
- [ ] Deploy and verify diagnosis appears in fallback messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)