### PR TITLE
docs: add 035 spec artifacts

### DIFF
--- a/specs/035-port-failover-downstream/checklists/requirements.md
+++ b/specs/035-port-failover-downstream/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Port AI Failover & Resilience to Downstream Repos
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-13
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [X] No implementation details (languages, frameworks, APIs)
+- [X] Focused on user value and business needs
+- [X] Written for non-technical stakeholders
+- [X] All mandatory sections completed
+
+## Requirement Completeness
+
+- [X] No [NEEDS CLARIFICATION] markers remain
+- [X] Requirements are testable and unambiguous
+- [X] Success criteria are measurable
+- [X] Success criteria are technology-agnostic (no implementation details)
+- [X] All acceptance scenarios are defined
+- [X] Edge cases are identified
+- [X] Scope is clearly bounded
+- [X] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [X] All functional requirements have clear acceptance criteria
+- [X] User scenarios cover primary flows
+- [X] Feature meets measurable outcomes defined in Success Criteria
+- [X] No implementation details leak into specification
+
+## Notes
+
+- Spec references specific file patterns (e.g., `_build_fallback_message()`) as existing behavior to preserve — this is architectural context, not implementation prescription.
+- Vision/image handling differences between providers noted as an edge case — will be resolved during planning phase.
+- The Assumptions section documents reasonable defaults for backup provider choice (OpenAI GPT) and model selection (gpt-4o-mini) based on family-meeting precedent.

--- a/specs/035-port-failover-downstream/data-model.md
+++ b/specs/035-port-failover-downstream/data-model.md
@@ -1,0 +1,70 @@
+# Data Model: Port AI Failover & Resilience
+
+## Entities
+
+### AI Provider Abstraction (SCC: `src/services/ai_provider.py`)
+
+Centralized module managing provider selection and format conversion.
+
+**Fields/Constants**:
+- `PRIMARY_TIMEOUT`: float — seconds before failover (45.0)
+- `BACKUP_TIMEOUT`: float — seconds for backup attempt (30.0)
+- `PRIMARY_MODEL`: str — Claude model identifier (from config)
+- `BACKUP_MODEL`: str — OpenAI model identifier (from config)
+
+**Public functions** (5, matching claude_svc.py signatures):
+- `classify_intent(message, conversation_history, active_jobs) → dict`
+- `parse_receipt(image_data, media_type) → dict`
+- `generate_social_caption(photo_data, media_type, context) → str`
+- `generate_paired_caption(before_data, after_data, media_type, context) → str`
+- `suggest_category(vendor, line_items, available_categories) → dict`
+
+**Internal converters**:
+- `_convert_tool_for_openai(tool_def) → dict` — Anthropic tool → OpenAI function
+- `_convert_tool_choice_for_openai(tool_choice) → str|dict` — forced tool mapping
+- `_convert_image_for_openai(image_block) → dict` — base64 source → data URI
+- `_convert_messages_for_openai(system, messages) → list[dict]` — full message conversion
+
+**Exception**:
+- `AllProvidersDownError(Exception)` — raised when both providers fail
+
+### Configuration Extension (SCC: `src/config.py`)
+
+New environment variables:
+- `OPENAI_API_KEY`: str — backup provider API key (optional)
+- `OPENAI_MODEL`: str — backup model, default `gpt-4o-mini`
+
+### Resilience Prompts (SCC: `src/prompts/system/05-resilience.md`)
+
+New system prompt section with rules:
+- Error transparency: always mention tool failures to the user
+- Diagnostic specificity: name the service and suggest actionable steps
+- Never present a failed action as successful
+
+### Template Scaffolding (speckit-template)
+
+Template versions of the above with `{{PLACEHOLDER}}` syntax:
+- `src/services/ai_provider.py` — 2 example functions, all converters, customization comments
+- `src/prompts/system/05-resilience.md` — template rules with `{{BUSINESS_NAME}}`
+
+## Relationships
+
+```
+config.py (env vars) ─────→ ai_provider.py (uses keys + model names)
+claude_svc.py ─────────────→ ai_provider.py (delegates all AI calls)
+router_svc.py ─────────────→ ai_provider.py (catches AllProvidersDownError)
+router_svc.py ─────────────→ _build_fallback_message() (both-down UX)
+health_svc.py ──────────────→ ai_provider.py (checks backup availability)
+05-resilience.md ──────────→ loaded by prompt system at startup
+```
+
+## State Transitions
+
+No new database entities. The failover is stateless — each request independently tries Claude then OpenAI. The existing `pending_actions` table in SCC is unaffected.
+
+Provider selection per request:
+```
+START → Try Claude → SUCCESS → Return (provider="claude")
+                   → FAIL (500/529/timeout) → Try OpenAI → SUCCESS → Return (provider="openai")
+                                                         → FAIL → Raise AllProvidersDownError
+```

--- a/specs/035-port-failover-downstream/plan.md
+++ b/specs/035-port-failover-downstream/plan.md
@@ -1,0 +1,130 @@
+# Implementation Plan: Port AI Failover & Resilience to Downstream Repos
+
+**Branch**: `035-port-failover-downstream` | **Date**: 2026-03-13 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `/specs/035-port-failover-downstream/spec.md`
+
+## Summary
+
+Port the AI failover & resilience patterns from family-meeting feature 034 to two downstream repos: **client-scc-tom-construction** (production app — new `ai_provider.py` module, tool result auditing, prompt rules) and **claude-speckit-template** (scaffolding — template files with customization comments). The SCC app adapts the pattern for its service-based architecture with 5 distinct Claude functions (classify, parse receipt, generate caption, paired caption, suggest category), including vision/image format conversion and forced tool_choice support.
+
+## Technical Context
+
+**Language/Version**: Python 3.11+ (SCC app), language-agnostic (template)
+**Primary Dependencies**: anthropic SDK, openai SDK (new for SCC), FastAPI, python-quickbooks, twilio, tenacity
+**Storage**: SQLite (SCC — conversations, pending actions, job aliases); N/A (template)
+**Testing**: pytest + pytest-asyncio (SCC); N/A (template)
+**Target Platform**: Railway (Linux server) for SCC; GitHub template for speckit
+**Project Type**: Cross-repo refactoring — web-service (SCC) + template scaffolding
+**Performance Goals**: <60s failover response, no latency change on primary path
+**Constraints**: SCC has 5 vision-capable Claude functions that must all fail over; template must be opt-in (not break non-AI projects)
+**Scale/Scope**: 2 repos, ~15 files modified/created across both
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Integration Over Building | PASS | Leverages existing OpenAI API — no custom AI built |
+| II. Mobile-First Access | PASS | No change to user-facing interface (SMS for SCC, WhatsApp for family-meeting) |
+| III. Simplicity & Low Friction | PASS | Failover is transparent — zero user action required |
+| IV. Structured Output | N/A | No meeting output changes |
+| V. Incremental Value | PASS | Each user story is independently deployable |
+
+**Post-design re-check**: All gates still pass. The centralized `ai_provider.py` adds one file per repo but reduces overall complexity vs. inline failover in every function.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/035-port-failover-downstream/
+├── plan.md              # This file
+├── research.md          # Phase 0: OpenAI vision, tool_choice, format conversion
+├── data-model.md        # Phase 1: Entity descriptions for both repos
+├── quickstart.md        # Phase 1: E2E validation scenarios
+└── tasks.md             # Phase 2: Task breakdown (via /speckit.tasks)
+```
+
+### Source Code Changes
+
+**Repo 1: client-scc-tom-construction** (`/Users/jabelk/dev/projects/client-scc-tom-construction/`)
+
+```text
+src/
+├── services/
+│   ├── ai_provider.py      # NEW — centralized failover (Claude → OpenAI)
+│   ├── claude_svc.py        # MODIFIED — delegate to ai_provider.py
+│   ├── router_svc.py        # MODIFIED — catch AllProvidersDownError
+│   └── health_svc.py        # MODIFIED — add backup provider health check
+├── config.py                # MODIFIED — add OPENAI_API_KEY, OPENAI_MODEL
+├── prompts/system/
+│   └── 05-resilience.md     # NEW — error reporting + diagnostic rules
+├── main.py                  # UNCHANGED
+
+tests/unit/
+├── test_ai_provider.py      # NEW — failover, format conversion, both-down
+├── test_graceful_degradation.py  # MODIFIED — add failover scenarios
+```
+
+**Repo 2: claude-speckit-template** (`/Users/jabelk/dev/projects/claude-speckit-template/`)
+
+```text
+src/
+├── services/
+│   └── ai_provider.py      # NEW — template with placeholders + comments
+├── prompts/system/
+│   └── 05-resilience.md     # NEW — template resilience rules
+
+CLAUDE.md                    # MODIFIED — add resilience architecture section
+```
+
+**Structure Decision**: SCC follows its existing `src/services/` layout. The new `ai_provider.py` sits alongside `claude_svc.py` as a peer service. Template repo mirrors this structure with placeholder files.
+
+## Architecture: SCC ai_provider.py
+
+### Public API (5 functions matching claude_svc.py)
+
+```python
+def classify_intent(message, conversation_history, active_jobs) -> dict
+def parse_receipt(image_data, media_type) -> dict
+def generate_social_caption(photo_data, media_type, context) -> str
+def generate_paired_caption(before_data, after_data, media_type, context) -> str
+def suggest_category(vendor, line_items, available_categories) -> dict
+```
+
+Each function: tries Claude first (45s timeout) → catches 500/529/timeout/connection → retries with OpenAI GPT-4o-mini (30s timeout) → raises `AllProvidersDownError` if both fail.
+
+### Key Conversion Patterns
+
+**Image format** (Anthropic → OpenAI):
+```
+Anthropic: {"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": b64}}
+OpenAI:    {"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,{b64}"}}
+```
+
+**Forced tool_choice** (Anthropic → OpenAI):
+```
+Anthropic: {"type": "tool", "name": "classify_message"}
+OpenAI:    {"type": "function", "function": {"name": "classify_message"}}
+```
+
+**Tool definitions** (same as family-meeting):
+```
+Anthropic: {"name": ..., "description": ..., "input_schema": {...}}
+OpenAI:    {"type": "function", "function": {"name": ..., "description": ..., "parameters": {...}}}
+```
+
+### Failover Integration Points
+
+| Component | Change | Why |
+|-----------|--------|-----|
+| `claude_svc.py` | Functions become thin delegates to `ai_provider.py` | Centralize failover logic |
+| `router_svc.py` | Catch `AllProvidersDownError` → `_build_fallback_message()` | Preserve existing UX |
+| `health_svc.py` | Add `check_openai_health()` | Monitor backup availability |
+| `config.py` | Add `OPENAI_API_KEY`, `OPENAI_MODEL` | Configure backup provider |
+| `05-resilience.md` | New system prompt section | Error transparency rules |
+
+## Complexity Tracking
+
+No constitution violations. The centralized module pattern adds one file but replaces what would otherwise be duplicated failover blocks in 5 functions.

--- a/specs/035-port-failover-downstream/quickstart.md
+++ b/specs/035-port-failover-downstream/quickstart.md
@@ -1,0 +1,109 @@
+# Quickstart: Port AI Failover & Resilience — E2E Validation
+
+## Prerequisites
+
+- Both repos cloned locally:
+  - `/Users/jabelk/dev/projects/client-scc-tom-construction/`
+  - `/Users/jabelk/dev/projects/claude-speckit-template/`
+- `OPENAI_API_KEY` set in SCC `.env`
+- `ANTHROPIC_API_KEY` set in SCC `.env`
+- SCC test suite passes: `uv run pytest tests/ -v`
+
+## Scenario 1: SCC — Claude Primary Path (No Failover)
+
+**Goal**: Verify normal operation is unchanged after refactoring.
+
+1. Start SCC dev server: `uv run uvicorn src.main:app --reload --port 8000`
+2. Send a test SMS via Twilio webhook (or use test script)
+3. **Verify**: Response comes from Claude (check logs for provider="claude")
+4. **Verify**: Intent classification, receipt parsing, and caption generation all work normally
+5. **Verify**: No latency regression (response time within normal range)
+
+## Scenario 2: SCC — Failover to OpenAI on Claude 529
+
+**Goal**: Verify automatic failover when Claude is overloaded.
+
+1. Create `test_failover_live.py` in SCC repo (mirrors family-meeting's pattern)
+2. Patch `anthropic.Anthropic` to raise `APIStatusError(529)`
+3. Call `ai_provider.classify_intent()` with a test message
+4. **Verify**: Response comes from OpenAI (provider="openai")
+5. **Verify**: Intent classification returns valid structured data
+6. **Verify**: Entities are correctly extracted
+
+## Scenario 3: SCC — Vision Failover (Receipt Parsing)
+
+**Goal**: Verify receipt parsing works on OpenAI backup.
+
+1. Patch Claude to fail with 529
+2. Call `ai_provider.parse_receipt()` with a test receipt image
+3. **Verify**: Receipt is parsed via OpenAI with vision
+4. **Verify**: Response includes vendor, date, total, line_items
+5. **Verify**: Image format was correctly converted (base64 → data URI)
+
+## Scenario 4: SCC — Vision Failover (Social Caption)
+
+**Goal**: Verify caption generation works on OpenAI backup.
+
+1. Patch Claude to fail with 529
+2. Call `ai_provider.generate_social_caption()` with a test photo
+3. **Verify**: Caption is generated via OpenAI with vision
+4. **Verify**: Caption includes text + hashtags
+
+## Scenario 5: SCC — Both Providers Down
+
+**Goal**: Verify graceful degradation when all AI is unavailable.
+
+1. Patch both Claude and OpenAI to fail
+2. Call `ai_provider.classify_intent()` — should raise `AllProvidersDownError`
+3. **Verify**: `router_svc.py` catches the error and returns `_build_fallback_message()`
+4. **Verify**: Fallback message lists keyword commands
+5. **Verify**: Pending actions are still accessible via keywords
+
+## Scenario 6: SCC — Tool Result Auditing
+
+**Goal**: Verify error detection in service call results.
+
+1. Simulate a QuickBooks API error during expense creation
+2. **Verify**: Error is detected and surfaced in the response to the user
+3. **Verify**: Response includes specific diagnostic context (e.g., "QuickBooks auth expired")
+4. **Verify**: Error is logged with structured context
+
+## Scenario 7: SCC — Resilience Prompt Rules
+
+**Goal**: Verify Claude follows error reporting rules.
+
+1. Trigger a tool failure in a conversation
+2. **Verify**: Claude mentions the specific failure in its response
+3. **Verify**: Claude provides actionable guidance (not vague "something went wrong")
+
+## Scenario 8: Template — Scaffolding Verification
+
+**Goal**: Verify template files exist and are well-structured.
+
+1. Check `/Users/jabelk/dev/projects/claude-speckit-template/src/services/ai_provider.py` exists
+2. **Verify**: Contains `{{PLACEHOLDER}}` patterns and customization comments
+3. **Verify**: Contains example failover functions with format converters
+4. Check `src/prompts/system/05-resilience.md` exists
+5. **Verify**: Contains template resilience rules with `{{BUSINESS_NAME}}`
+6. Check CLAUDE.md has resilience architecture section
+7. **Verify**: Section describes the ai_provider pattern and customization steps
+
+## Scenario 9: SCC — Full Test Suite Regression
+
+**Goal**: Verify zero regressions.
+
+1. Run `uv run pytest tests/ -v` in SCC repo
+2. **Verify**: All existing tests pass
+3. **Verify**: New `test_ai_provider.py` tests pass
+4. Run `uv run ruff check src/ tests/` — clean
+5. Run `uv run ruff format --check src/ tests/` — clean
+
+## Scenario 10: SCC — Deploy and Health Check
+
+**Goal**: Verify production deployment.
+
+1. Set `OPENAI_API_KEY` on Railway
+2. Deploy to Railway
+3. **Verify**: `GET /health` returns healthy with backup provider info
+4. Send a test SMS through production
+5. **Verify**: Response received normally (primary path)

--- a/specs/035-port-failover-downstream/research.md
+++ b/specs/035-port-failover-downstream/research.md
@@ -1,0 +1,79 @@
+# Research: Port AI Failover & Resilience to Downstream Repos
+
+## 1. OpenAI Vision API Format
+
+**Decision**: Use OpenAI's `image_url` format with data URI for base64 images.
+
+**Rationale**: GPT-4o-mini fully supports vision input. The conversion from Anthropic's `source.data` base64 to OpenAI's data URI is straightforward — wrap the base64 data in `data:{mime_type};base64,{data}`.
+
+**Conversion**:
+- Anthropic: `{"type": "image", "source": {"type": "base64", "media_type": "image/jpeg", "data": b64}}`
+- OpenAI: `{"type": "image_url", "image_url": {"url": "data:image/jpeg;base64,{b64}"}}`
+
+**Alternatives considered**:
+- Upload images to a URL first → unnecessary complexity, adds storage dependency
+- Skip vision on backup → rejected per clarification (always attempt vision)
+
+## 2. OpenAI Forced tool_choice
+
+**Decision**: Convert Anthropic's `{"type": "tool", "name": "..."}` to OpenAI's `{"type": "function", "function": {"name": "..."}}`.
+
+**Rationale**: OpenAI GPT-4o-mini fully supports forced function calling. All three SCC forced-tool patterns (classify_message, extract_receipt, generate_caption) will work identically on OpenAI.
+
+**Conversion mapping**:
+- `{"type": "tool", "name": "X"}` → `{"type": "function", "function": {"name": "X"}}`
+- `{"type": "any"}` → `"required"`
+- `{"type": "auto"}` → `"auto"`
+- `None` → `None` (omit parameter)
+
+**Alternatives considered**:
+- Use `response_format` for structured output → doesn't support function calling semantics
+- Prompt-only approach without tool_choice → lower reliability for entity extraction
+
+## 3. SCC Architecture Analysis
+
+**Decision**: New centralized `src/services/ai_provider.py` with 5 public functions mirroring `claude_svc.py`.
+
+**Rationale**: Per clarification, Option A (centralized module) chosen for multi-client reuse. The module exposes the same function signatures as `claude_svc.py` so callers don't change. Internally, each function implements the try-Claude/catch/try-OpenAI/catch/raise pattern with appropriate format conversions.
+
+**Current SCC architecture**:
+- `claude_svc.py`: 5 functions, each creates messages directly via `anthropic.Anthropic` singleton
+- `router_svc.py`: Calls `claude_svc.classify_intent()` with try/except, falls back to `_build_fallback_message()`
+- Error handling: QBO uses tenacity retries; Claude calls have no retry/failover
+- Health check: Claude only checks env var (no API ping)
+
+**Integration approach**:
+1. `ai_provider.py` contains all provider logic + format converters
+2. `claude_svc.py` becomes thin wrappers that call `ai_provider.py`
+3. `router_svc.py` catches `AllProvidersDownError` → `_build_fallback_message()`
+4. No changes to `twilio.py` or `main.py` (error handling already propagates)
+
+**Alternatives considered**:
+- Inline failover in each claude_svc function (Option B) → code duplication across 5 functions, compounds across client projects
+- Client factory (Option C) → doesn't work because Anthropic and OpenAI have fundamentally different APIs
+
+## 4. GPT-4o-mini Vision Capability
+
+**Decision**: Use `gpt-4o-mini` as the backup model for all functions including vision.
+
+**Rationale**: GPT-4o-mini supports vision input at $0.15/1M input tokens — cheapest vision-capable OpenAI model. Receipt parsing and caption generation will work on the backup provider without model switching.
+
+**Alternatives considered**:
+- `gpt-4.1-nano` ($0.10/1M) — slightly cheaper, newer (April 2025), but less battle-tested
+- `gpt-4o` ($2.50/1M) — overkill for failover backup at 16x the cost
+- Separate models for vision vs text — unnecessary complexity since gpt-4o-mini handles both
+
+## 5. Template Repo Approach
+
+**Decision**: Add opt-in scaffolding files with `{{PLACEHOLDER}}` patterns and detailed comments.
+
+**Rationale**: Template repo has no production code. Adding real Python files with placeholder patterns lets new projects customize rather than implement from scratch. Files are clearly marked as templates with customization instructions.
+
+**Files to add**:
+- `src/services/ai_provider.py` — template with 2 example functions, all conversion logic, placeholder model names
+- `src/prompts/system/05-resilience.md` — template resilience rules with `{{BUSINESS_NAME}}` / `{{OWNER_NAME}}` placeholders
+- CLAUDE.md update — resilience architecture section
+
+**Alternatives considered**:
+- Documentation only (no template files) → developers would rewrite from scratch each time
+- Full working code → impossible in a language-agnostic template

--- a/specs/035-port-failover-downstream/spec.md
+++ b/specs/035-port-failover-downstream/spec.md
@@ -1,0 +1,127 @@
+# Feature Specification: Port AI Failover & Resilience to Downstream Repos
+
+**Feature Branch**: `035-port-failover-downstream`
+**Created**: 2026-03-13
+**Status**: Draft
+**Input**: User description: "Refactor downstream repos (claude-speckit-template and client-scc-tom-construction) to incorporate AI failover & resilience patterns from family-meeting feature 034."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - SCC App: Backup AI Provider Failover (Priority: P1)
+
+When Claude is unavailable (500/529/timeout), Tom's construction bookkeeper bot should automatically switch to a backup AI provider so Tom still gets responses for intent classification, receipt parsing, and social caption generation. Today, if Claude goes down, the bot falls back to keyword-only commands with no AI capability — Tom can only approve/reject pending actions.
+
+**Why this priority**: Tom relies on the bot for daily bookkeeping. A Claude outage means no receipt parsing, no intent classification, and no social media posts — core revenue-impacting features go offline.
+
+**Independent Test**: Simulate a Claude API failure in the SCC app, verify that intent classification, receipt parsing, and caption generation all respond via the backup provider.
+
+**Acceptance Scenarios**:
+
+1. **Given** Claude API returns a 529 overloaded error, **When** Tom sends a text message with a receipt photo, **Then** the receipt is parsed via the backup provider and Tom receives a confirmation prompt as normal.
+2. **Given** Claude API times out after the configured threshold, **When** Tom sends a text describing an expense, **Then** intent classification happens via the backup provider and the expense flow proceeds normally.
+3. **Given** both Claude and the backup provider are unavailable, **When** Tom sends any message, **Then** the bot sends a static fallback message explaining the issue and listing keyword commands still available.
+4. **Given** Claude is available, **When** Tom sends a message, **Then** the primary provider handles it with no change in behavior or latency.
+
+---
+
+### User Story 2 - Template Repo: Resilience Scaffolding for New Projects (Priority: P2)
+
+When a developer scaffolds a new project from the claude-speckit-template, the project should include ready-to-customize patterns for AI failover, tool result auditing, and resilience prompts — so every new project starts with resilience built in rather than bolting it on later.
+
+**Why this priority**: The template is the starting point for all new client projects. Including resilience patterns from day one prevents the same technical debt from accumulating in every downstream project.
+
+**Independent Test**: Fork the template, verify that the resilience scaffolding files exist with clear customization instructions, and confirm placeholder patterns match the family-meeting reference implementation.
+
+**Acceptance Scenarios**:
+
+1. **Given** a developer creates a new project from the template, **When** they review the project structure, **Then** they find a template AI provider module with failover patterns and customization comments.
+2. **Given** a developer creates a new project from the template, **When** they review the prompt directory structure, **Then** they find a resilience prompt template for lost message detection and error surfacing rules.
+3. **Given** a developer creates a new project from the template, **When** they review CLAUDE.md, **Then** the active technologies section documents the backup AI provider pattern and the resilience architecture.
+
+---
+
+### User Story 3 - SCC App: Tool Result Auditing & Error Surfacing (Priority: P2)
+
+When a tool call in the SCC app fails (QuickBooks API error, Twilio send failure, Ayrshare posting error), the bot should detect the error and inform Tom explicitly — never presenting a failed action as successful or silently swallowing the error.
+
+**Why this priority**: Silent tool failures in a financial bookkeeping app can lead to missing expense records, duplicate invoices, or lost receipts — directly impacting Tom's business finances.
+
+**Independent Test**: Simulate a QuickBooks API failure during expense creation, verify the bot tells Tom the expense was not recorded and suggests next steps.
+
+**Acceptance Scenarios**:
+
+1. **Given** QuickBooks API returns an error during expense creation, **When** Tom is waiting for confirmation, **Then** the bot explicitly tells Tom the expense was not recorded and suggests retrying or manually entering it.
+2. **Given** Twilio fails to send a response SMS, **When** any handler tries to reply, **Then** the failure is logged with diagnostic context.
+3. **Given** Ayrshare returns an error during social media posting, **When** Tom sent a photo to post, **Then** the bot tells Tom the post failed and why.
+
+---
+
+### User Story 4 - SCC App: Resilience Prompt Rules (Priority: P3)
+
+The SCC bot should include prompt-level rules for error reporting and diagnostic transparency — ensuring Claude always mentions failures to Tom and provides actionable guidance rather than vague error messages.
+
+**Why this priority**: Prompt rules are low-effort, high-impact improvements that complement the code-level changes in US1 and US3.
+
+**Independent Test**: Verify the SCC system prompts include rules about error reporting, and test that Claude references specific error details when a tool failure occurs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tool result contains an error indicator, **When** Claude generates a response, **Then** the response mentions the specific failure and provides actionable guidance.
+2. **Given** an external service is unavailable, **When** Claude generates a response, **Then** the response names the specific service and suggests what Tom can do.
+
+---
+
+### Edge Cases
+
+- What happens when the backup provider's vision call fails? The system converts image formats and always attempts vision on the backup; if it still fails, the user receives a specific error message explaining the image could not be processed and to try again later.
+- What happens when the backup provider returns a different tool call format than expected for forced tool_choice patterns?
+- How does the template handle projects that don't use AI at all? (Template resilience patterns should be opt-in, not mandatory)
+- What happens when the SCC app is mid-conversation and fails over? (Conversation context must be preserved across providers)
+- What happens when the backup provider's category suggestion differs from what QuickBooks expects?
+
+## Clarifications
+
+### Session 2026-03-13
+
+- Q: Should the SCC app get a new centralized `ai_provider.py` module (Option A), wrap failover inline in existing functions (Option B), or use a client factory (Option C)? → A: Option A — New centralized `ai_provider.py` module. This supports multi-client reuse: one portable module per project, single place to add providers/change config, and new AI functions don't need failover boilerplate.
+- Q: When vision-based functions (receipt parsing, caption generation) fail over to the backup provider, should vision be attempted, skipped, or degraded to text-only? → A: Option A — Always attempt vision on backup provider with image format conversion. Fail gracefully with an error message if vision specifically fails.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The SCC app MUST attempt the backup AI provider when Claude returns HTTP 500, 529, or times out — matching the family-meeting failover trigger conditions.
+- **FR-002**: The SCC app's backup provider MUST support all four Claude call patterns: intent classification (forced tool use), receipt parsing (vision + forced tool use), social caption generation (vision + forced tool use), and category suggestion (text completion).
+- **FR-003**: The SCC app MUST send a static fallback message listing keyword commands when both AI providers are unavailable, preserving the existing `_build_fallback_message()` behavior.
+- **FR-004**: The SCC app MUST add error detection that identifies failure indicators in service call results (QuickBooks errors, Twilio failures, Ayrshare errors) and surfaces them in responses to the user.
+- **FR-005**: The SCC app MUST add prompt rules for error transparency — the AI must mention failures and provide specific diagnostic context rather than vague messages.
+- **FR-006**: The template repo MUST include a scaffolding file for AI provider failover with clear customization comments and placeholder patterns.
+- **FR-007**: The template repo MUST include a resilience prompt template in the system prompts directory.
+- **FR-008**: The template repo MUST update CLAUDE.md to document the resilience architecture patterns.
+- **FR-009**: All changes to the SCC app MUST pass the existing test suite with no regressions.
+- **FR-010**: The SCC app MUST introduce a new centralized `ai_provider.py` module that encapsulates all provider selection, format conversion, and failover logic. Existing `claude_svc.py` functions MUST be refactored to route through this module. The module MUST be designed for portability across client projects — one file to copy, single place to configure providers, models, and timeouts.
+
+### Key Entities
+
+- **AI Provider Abstraction**: Centralized module managing primary (Claude) and backup provider selection, format conversion, and failover logic — adapted to each repo's architecture.
+- **Tool Result Audit**: Error detection layer that inspects service call results for failure indicators and prepends warning context before passing to the AI.
+- **Resilience Prompts**: System-level prompt rules that instruct the AI to surface errors, provide diagnostic context, and never present failures as successes.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: The SCC app continues to respond to user messages within 60 seconds even when Claude is completely unavailable — verified by simulating Claude outage and measuring response time.
+- **SC-002**: 100% of tool/service failures in the SCC app are surfaced to the user with a specific error description — verified by simulating failures for each integration (QBO, Twilio, Ayrshare) and checking response text.
+- **SC-003**: New projects created from the template include resilience scaffolding files — verified by creating a test project and checking for the expected files.
+- **SC-004**: All existing tests in both repos continue to pass after changes — zero regressions.
+- **SC-005**: The SCC app's forced tool_choice patterns work correctly with the backup provider — verified by running each AI function (classify, parse, caption, suggest) against the backup.
+
+## Assumptions
+
+- The backup AI provider for the SCC app will be OpenAI GPT (same as family-meeting), since it has the broadest tool-use and vision support.
+- The SCC app's forced `tool_choice` pattern will be adapted to OpenAI's equivalent (`tool_choice: {"type": "function", "function": {"name": "..."}}` or similar).
+- The template repo changes are documentation/scaffolding only — no production code runs in the template.
+- The SCC app uses `claude-haiku-4-5-20251001` as its model; the backup will be `gpt-4o-mini` (matching family-meeting's choice).
+- Vision-based functions (receipt parsing, caption generation) will need special handling since OpenAI uses a different image input format than Anthropic.
+- The SCC app's existing `_build_fallback_message()` in router_svc.py provides the both-providers-down user experience and should be preserved.


### PR DESCRIPTION
## Summary
- Adds the speckit workflow artifacts (spec, plan, research, data-model, quickstart, checklists) for feature 035 — port AI failover to downstream repos
- Docs-only change, no code modifications

## Test plan
- [x] CI gate passes (docs-only, should skip lint/test/security)

🤖 Generated with [Claude Code](https://claude.com/claude-code)