### PR TITLE
fix: correct Due Context case to match Notion option

### DIFF
--- a/src/assistant.py
+++ b/src/assistant.py
@@ -144,8 +144,8 @@ _ALL_TOOLS = [
                 "description": {"type": "string", "description": "What needs to be done."},
                 "due_context": {
                     "type": "string",
-                    "description": "When: 'This Week', 'Ongoing', or 'Someday'. Default 'This Week'.",
-                    "default": "This Week",
+                    "description": "When: 'This week', 'Ongoing', or 'Someday'. Default 'This week'.",
+                    "default": "This week",
                 },
             },
             "required": ["assignee", "description"],
@@ -1486,7 +1486,7 @@ TOOL_FUNCTIONS = {
     "get_outlook_events": lambda **kw: outlook.get_outlook_events(kw.get("date", "")),
     "get_action_items": lambda **kw: notion.get_action_items(kw.get("assignee", ""), kw.get("status", "")),
     "add_action_item": lambda **kw: notion.add_action_item(
-        kw["assignee"], kw["description"], kw.get("due_context", "This Week")
+        kw["assignee"], kw["description"], kw.get("due_context", "This week")
     ),
     "complete_action_item": lambda **kw: notion.complete_action_item(kw["page_id"]),
     "add_topic": lambda **kw: notion.add_topic(kw["description"]),

--- a/src/mcp_server.py
+++ b/src/mcp_server.py
@@ -89,8 +89,8 @@ def get_action_items(assignee: str = "", status: str = "") -> str:
 
 
 @mcp.tool()
-def add_action_item(assignee: str, description: str, due_context: str = "This Week") -> str:
-    """Create a new action item assigned to a family member. Due context: "This Week", "Ongoing", or "Someday"."""
+def add_action_item(assignee: str, description: str, due_context: str = "This week") -> str:
+    """Create a new action item assigned to a family member. Due context: "This week", "Ongoing", or "Someday"."""
     return notion.add_action_item(assignee, description, due_context)
 
 
@@ -102,7 +102,7 @@ def complete_action_item(page_id: str) -> str:
 
 @mcp.tool()
 def rollover_incomplete_items() -> str:
-    """Mark all incomplete "This Week" action items as rolled over. Call when generating a new weekly agenda."""
+    """Mark all incomplete "This week" action items as rolled over. Call when generating a new weekly agenda."""
     return notion.rollover_incomplete_items()
 
 

--- a/src/prompts/tools/notion.md
+++ b/src/prompts/tools/notion.md
@@ -28,7 +28,7 @@ Create a new meeting record in Notion for today (or a specific date). Returns th
 
 ## rollover_incomplete_items
 
-Mark all incomplete 'This Week' action items as rolled over. Call this when generating a new weekly agenda.
+Mark all incomplete 'This week' action items as rolled over. Call this when generating a new weekly agenda.
 
 ## save_meal_plan
 

--- a/src/tools/notion.py
+++ b/src/tools/notion.py
@@ -142,7 +142,7 @@ def get_action_items(assignee: str = "", status: str = "") -> str:
 def add_action_item(
     assignee: str,
     description: str,
-    due_context: str = "This Week",
+    due_context: str = "This week",
     meeting_id: str = "",
 ) -> str:
     """Create a new action item in the Action Items database."""
@@ -211,7 +211,7 @@ def rollover_incomplete_items() -> str:
         filter={
             "and": [
                 {"property": "Status", "status": {"does_not_equal": "Done"}},
-                {"property": "Due Context", "select": {"equals": "This Week"}},
+                {"property": "Due Context", "select": {"equals": "This week"}},
             ]
         },
     )

--- a/src/tools/proactive.py
+++ b/src/tools/proactive.py
@@ -423,7 +423,7 @@ def check_action_item_progress() -> dict:
     try:
         results = notion_client.databases.query(
             database_id=NOTION_ACTION_ITEMS_DB,
-            filter={"property": "Due Context", "select": {"equals": "This Week"}},
+            filter={"property": "Due Context", "select": {"equals": "This week"}},
         )
     except Exception as e:
         logger.error("Failed to query action items: %s", e)


### PR DESCRIPTION
## Summary

- Fixes case sensitivity bug where code used `"This Week"` (capital W) but the Notion database option is `"This week"` (lowercase w)
- This caused Notion filters in `rollover_incomplete_items()` and `check_action_item_progress()` to silently return zero results
- Also fixed default values in `add_action_item()` across `notion.py`, `assistant.py`, `mcp_server.py`, and the tool description prompt

## Files changed

| File | Change |
|------|--------|
| `src/tools/proactive.py` | Filter query: `"This Week"` → `"This week"` |
| `src/tools/notion.py` | Filter query + default param: `"This Week"` → `"This week"` |
| `src/assistant.py` | Tool schema default + description: `"This Week"` → `"This week"` |
| `src/mcp_server.py` | Default param + docstrings: `"This Week"` → `"This week"` |
| `src/prompts/tools/notion.md` | Tool description: `"This Week"` → `"This week"` |

## Test plan

- [ ] Verify `rollover_incomplete_items()` now correctly finds incomplete "This week" items
- [ ] Verify `check_action_item_progress()` returns non-zero results for current week's items
- [ ] Verify `add_action_item()` creates items with the correct `"This week"` select value
- [ ] CI passes (lint, tests, security scan)

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)